### PR TITLE
use okhttp 3.12.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     implementation 'com.journeyapps:zxing-android-embedded:3.6.0'
 
     // Okhttp network access. 3.12.x is API level < 21, 3.13 or better requires API 21
-    implementation 'com.squareup.okhttp3:okhttp:4.2.2'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.6'
 
     // ani gif support
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.15'


### PR DESCRIPTION
we support API level < 21, so we have to use the version 3.12.x