### PR TITLE
extend android permission handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,5 +91,6 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.12.6'
 
     // ani gif support
+    // minSdk=17 from version 1.2.16
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.15'
 }

--- a/src/main/java/menion/android/whereyougo/permission/PermissionHandler.java
+++ b/src/main/java/menion/android/whereyougo/permission/PermissionHandler.java
@@ -1,0 +1,135 @@
+package menion.android.whereyougo.permission;
+
+import android.Manifest;
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.Settings;
+import android.support.v4.app.ActivityCompat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import menion.android.whereyougo.R;
+import menion.android.whereyougo.utils.Logger;
+
+import static menion.android.whereyougo.preferences.Locale.getString;
+
+public class PermissionHandler {
+
+    private static final String TAG = "PermissionHandler";
+
+    private PermissionHandler() {
+        // Utility class should not be instantiated externally
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    public static void checkPermissions(final Activity activity) {
+
+        final String[] permissions = new String[] {
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE,
+        };
+
+        String[] koPermissions = checkKoPermissions(activity, permissions);
+        if (koPermissions.length > 0) {
+            askFor(activity, koPermissions);
+        }
+    }
+
+    public static String[] checkKoPermissions(final Activity activity, final String[] permissions) {
+    List<String> listKoPermissions = new ArrayList<>();
+        for (String permission: permissions) {
+            if (ActivityCompat.checkSelfPermission(activity, permission) != PackageManager.PERMISSION_GRANTED) {
+                listKoPermissions.add(permission);
+            }
+        }
+        return listKoPermissions.toArray(new String[0]);
+    }
+
+    /*
+     * Check if version is marshmallow and above.
+     * Used in deciding to ask runtime permission
+     * */
+    public static boolean needAskForPermission() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
+    }
+
+    public static void askAgainFor(final Activity activity, String[] permissions) {
+        int permissionsDenied = 0;
+        HashMap<String, Integer> permissionClasses = new HashMap<>();
+        for (String permission:permissions) {
+            permissionClasses.put(getPermissionClass(permission), 1);
+            final boolean currShouldShowStatus = ActivityCompat.shouldShowRequestPermissionRationale(activity, permission);
+            if (!currShouldShowStatus) {
+                permissionsDenied++;
+            }
+        }
+
+        String permissionsMessage = "";
+        for (String permissionClass: permissionClasses.keySet()) {
+            permissionsMessage = permissionsMessage.concat((permissionsMessage.isEmpty() ? "" : "\n\n")).concat(getPermissionMessage(permissionClass));
+        }
+        permissionsMessage = permissionsMessage.concat("\n\n").concat(getString(R.string.permission_conclusion));
+
+        if (permissionsDenied == 0) {
+            // Show permission explanation dialog...
+            new AlertDialog.Builder(activity)
+                    .setMessage(permissionsMessage)
+                    .setCancelable(false)
+                    .setNeutralButton(R.string.ask_again, (dialog, which) -> askFor(activity, permissions))
+                    .create()
+                    .show();
+        } else {
+            // Never ask again selected, or device policy prohibits the app from having that permission.
+            // So, disable that feature, or fall back to another situation...
+            new AlertDialog.Builder(activity)
+                    .setMessage(permissionsMessage)
+                    .setCancelable(false)
+                    .setNegativeButton(R.string.close_app, (dialog, which) -> activity.finish())
+                    .setPositiveButton(R.string.goto_app_details, (dialog, which) -> {
+                                final Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                                        Uri.fromParts("package", activity.getPackageName(), null));
+                                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                                activity.startActivity(intent);
+                                activity.finish();
+                            }
+                    )
+                    .create()
+                    .show();
+        }
+    }
+
+    private static void askFor(final Activity activity, final String[] permissions) {
+        ActivityCompat.requestPermissions(activity, permissions, 0);
+    }
+
+    private static String getPermissionClass(final String permission) {
+        if (permission.equals(Manifest.permission.ACCESS_FINE_LOCATION) || permission.equals(Manifest.permission.ACCESS_COARSE_LOCATION)) {
+            return "LOCATION";
+        } else if (permission.equals(Manifest.permission.READ_EXTERNAL_STORAGE) || permission.equals(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+            return "STORAGE";
+        }
+
+        Logger.w(TAG, "getPermissionClass(), unknown permission: " + permission);
+        return "";
+    }
+
+    private static String getPermissionMessage(final String permissionClass) {
+        if (permissionClass.equals("LOCATION")) {
+            return getString(R.string.location_permission_request_explanation);
+        } else if (permissionClass.equals("STORAGE")) {
+            return getString(R.string.storage_permission_request_explanation);
+        }
+
+        Logger.w(TAG, "getPermissionMessage(), unknown permission class: " + permissionClass);
+        return "";
+    }
+}

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -121,4 +121,13 @@ Wenn du sich nicht sicher sind, setze den \"Wherigo Ordner\" auf automatisch.
     <string name="zone_state_inside">Innerhalb</string>
     <string name="zone_state_near">In der Nähe</string>
     <string name="zone_state_unknown">Unbekannt</string>
+
+    <!-- permission handling -->
+    <string name="close_app">App schließen</string>
+    <string name="ask_again">Erneut fragen</string>
+    <string name="goto_app_details">\"App-Info\" öffnen</string>
+    <string name="location_permission_request_explanation">WhereYouGo benötigt Zugriff auf das GPS deines Gerätes, um seine Position zu bestimmen sowie um Entfernungen und Richtungen zu Orten der cartridge zu berechnen.</string>
+    <string name="storage_permission_request_explanation">WhereYouGo muss Daten in den Speicher bzw. die externe Karte schreiben, sobald die catridge gespeichert wird.</string>
+    <string name="permission_conclusion">Die App kann ohne diese Berechtigung(en) nicht genutzt werden.</string>
+
 </resources>

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -126,8 +126,8 @@ Wenn du sich nicht sicher sind, setze den \"Wherigo Ordner\" auf automatisch.
     <string name="close_app">App schließen</string>
     <string name="ask_again">Erneut fragen</string>
     <string name="goto_app_details">\"App-Info\" öffnen</string>
-    <string name="location_permission_request_explanation">WhereYouGo benötigt Zugriff auf das GPS deines Gerätes, um seine Position zu bestimmen sowie um Entfernungen und Richtungen zu Orten der cartridge zu berechnen.</string>
-    <string name="storage_permission_request_explanation">WhereYouGo muss Daten in den Speicher bzw. die externe Karte schreiben, sobald die catridge gespeichert wird.</string>
+    <string name="location_permission_request_explanation">WhereYouGo benötigt Zugriff auf das GPS deines Gerätes, um seine Position zu bestimmen sowie um Entfernungen und Richtungen zu Orten der Cartridge zu berechnen.</string>
+    <string name="storage_permission_request_explanation">WhereYouGo muss Daten in den Speicher bzw. die externe Karte schreiben, sobald die Catridge gespeichert wird.</string>
     <string name="permission_conclusion">Die App kann ohne diese Berechtigung(en) nicht genutzt werden.</string>
 
 </resources>

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -127,7 +127,7 @@ Wenn du sich nicht sicher sind, setze den \"Wherigo Ordner\" auf automatisch.
     <string name="ask_again">Erneut fragen</string>
     <string name="goto_app_details">\"App-Info\" öffnen</string>
     <string name="location_permission_request_explanation">WhereYouGo benötigt Zugriff auf das GPS deines Gerätes, um seine Position zu bestimmen sowie um Entfernungen und Richtungen zu Orten der Cartridge zu berechnen.</string>
-    <string name="storage_permission_request_explanation">WhereYouGo muss Daten in den Speicher bzw. die externe Karte schreiben, sobald die Catridge gespeichert wird.</string>
+    <string name="storage_permission_request_explanation">WhereYouGo muss Daten in den Speicher bzw. die externe Karte schreiben, sobald die Cartridge gespeichert wird.</string>
     <string name="permission_conclusion">Die App kann ohne diese Berechtigung(en) nicht genutzt werden.</string>
 
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -126,8 +126,8 @@ If you\'re not sure, set \"Wherigo folder\" automatically.
     <string name="close_app">Close app</string>
     <string name="ask_again">Ask me again</string>
     <string name="goto_app_details">Open Application Info</string>
-    <string name="location_permission_request_explanation">WhereYouGo needs access to the GPS on your device to locate your position and calculate distance and direction to the cartridge locations.</string>
-    <string name="storage_permission_request_explanation">WhereYouGo will write data onto your phone storage or SD card as soon as you save the catridges.</string>
+    <string name="location_permission_request_explanation">WhereYouGo needs access to the GPS on your device to locate your position and calculate distance and direction to the Cartridge locations.</string>
+    <string name="storage_permission_request_explanation">WhereYouGo will write data onto your phone storage or SD card as soon as you save the Catridges.</string>
     <string name="permission_conclusion">The app cannot be used without this permission(s).</string>
 
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -121,4 +121,13 @@ If you\'re not sure, set \"Wherigo folder\" automatically.
     <string name="zone_state_inside">inside</string>
     <string name="zone_state_near">near</string>
     <string name="zone_state_unknown">unknown</string>
+
+    <!-- permission handling -->
+    <string name="close_app">Close app</string>
+    <string name="ask_again">Ask me again</string>
+    <string name="goto_app_details">Open Application Info</string>
+    <string name="location_permission_request_explanation">WhereYouGo needs access to the GPS on your device to locate your position and calculate distance and direction to the cartridge locations.</string>
+    <string name="storage_permission_request_explanation">WhereYouGo will write data onto your phone storage or SD card as soon as you save the catridges.</string>
+    <string name="permission_conclusion">The app cannot be used without this permission(s).</string>
+
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -127,7 +127,7 @@ If you\'re not sure, set \"Wherigo folder\" automatically.
     <string name="ask_again">Ask me again</string>
     <string name="goto_app_details">Open Application Info</string>
     <string name="location_permission_request_explanation">WhereYouGo needs access to the GPS on your device to locate your position and calculate distance and direction to the Cartridge locations.</string>
-    <string name="storage_permission_request_explanation">WhereYouGo will write data onto your phone storage or SD card as soon as you save the Catridges.</string>
+    <string name="storage_permission_request_explanation">WhereYouGo will write data onto your phone storage or SD card as soon as you save the Cartridge.</string>
     <string name="permission_conclusion">The app cannot be used without this permission(s).</string>
 
 </resources>


### PR DESCRIPTION
fixes #2

After PR #6 (+ #9) we had the app targeted to targetSdk 28.

The minimal Android permission handling to meet the requirements of targetSdk 28 was already realized in the original implementation.
This PR polishes the Android permission handling with additional messages and "never ask again" support.