### PR TITLE
fix: missing strip tool for ABI 'ARMEABI'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,11 @@ android {
         abortOnError false
         checkReleaseBuilds false
     }
+
+    packagingOptions {
+        // exclude ARMEABI native so file, ARMEABI has been removed in NDK r17.
+        exclude "lib/armeabi/**"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
fix #48

exclude ARMEABI native so file, ARMEABI has been removed in NDK r17.