### PR TITLE
delete unneeded lines from strings_mapsforge.xml

### DIFF
--- a/src/main/res/values-cs/strings_mapsforge.xml
+++ b/src/main/res/values-cs/strings_mapsforge.xml
@@ -26,8 +26,6 @@
     </string-array>
 
     <string name="application_name">Mapsforge</string>
-    <!-- 	<string name="cancel">Zrušit</string> -->
-    <!-- 	<string name="error">Chyba</string> -->
     <string name="error_last_location_unknown">Poslední pozice je neznámá</string>
     <string name="file_invalid">Vybraný soubor je neplatný.</string>
     <string name="file_select">Prosím, vyberte soubor.</string>
@@ -50,8 +48,6 @@
     <string name="info_map_file_start_position">Počáteční pozice</string>
     <string name="info_map_file_start_zoom_level">Počáteční přiblížení</string>
     <string name="info_map_file_version">Verze</string>
-    <!-- 	<string name="latitude">Zeměpisná šířka</string> -->
-    <!-- 	<string name="longitude">Zeměpisná délka</string> -->
     <string name="menu_info">Informace</string>
     <string name="menu_info_map_file">Vlastnosti mapy</string>
     <string name="menu_info_about">O programu</string>
@@ -74,7 +70,6 @@
     <string name="menu_screenshot_jpeg">JPEG (ztrátový)</string>
     <string name="menu_screenshot_png">PNG (bezztrátový)</string>
     <string name="no_location_provider_available">Není dostupný žádný poskytovatel pozice</string>
-    <!-- 	<string name="ok">OK</string> -->
     <string name="preferences_debug">Nastavení pro vývojáře</string>
     <string name="preferences_general">Obecné nastavení</string>
     <string name="preferences_cache_persistence">Platnost vyrovnávací paměti</string>

--- a/src/main/res/values-da/strings_mapsforge.xml
+++ b/src/main/res/values-da/strings_mapsforge.xml
@@ -26,8 +26,6 @@
     </string-array>
 
     <string name="application_name">Mapsforge</string>
-    <!-- 	<string name="cancel">Cancel</string> -->
-    <!-- 	<string name="error">Error</string> -->
     <string name="error_last_location_unknown">Den sidste placering er ukendt</string>
     <string name="file_invalid">Den valgte fil er ugyldig.</string>
     <string name="file_select">Vælg venligst en fil.</string>
@@ -50,8 +48,6 @@
     <string name="info_map_file_start_position">Startposition</string>
     <string name="info_map_file_start_zoom_level">Start-zoomniveau</string>
     <string name="info_map_file_version">Version</string>
-    <!-- 	<string name="latitude">Latitude</string> -->
-    <!-- 	<string name="longitude">Longitude</string> -->
     <string name="menu_info">Info</string>
     <string name="menu_info_map_file">Kortfil egenskaber</string>
     <string name="menu_info_about">Om dette software</string>
@@ -73,7 +69,6 @@
     <string name="menu_screenshot_jpeg">JPEG (lossy)</string>
     <string name="menu_screenshot_png">PNG (lossless)</string>
     <string name="no_location_provider_available">Ingen placeringskilde tilgængelig</string>
-    <!-- 	<string name="ok">OK</string> -->
     <string name="preferences_debug">Debug-indstillinger</string>
     <string name="preferences_general">Generelle indstillinger</string>
     <string name="preferences_cache_persistence">Cache</string>

--- a/src/main/res/values-de/strings_mapsforge.xml
+++ b/src/main/res/values-de/strings_mapsforge.xml
@@ -26,8 +26,6 @@
     </string-array>
 
     <string name="application_name">Mapsforge</string>
-    <!-- 	<string name="cancel">Abbrechen</string> -->
-    <!-- 	<string name="error">Fehler</string> -->
     <string name="error_last_location_unknown">Die letzte Position ist unbekannt</string>
     <string name="file_invalid">Die gewählte Datei ist ungültig.</string>
     <string name="file_select">Bitte wählen Sie eine Datei.</string>
@@ -50,8 +48,6 @@
     <string name="info_map_file_start_position">Startposition</string>
     <string name="info_map_file_start_zoom_level">Start-Zoomstufe</string>
     <string name="info_map_file_version">Version</string>
-    <!-- 	<string name="latitude">Breitengrad</string> -->
-    <!-- 	<string name="longitude">Längengrad</string> -->
     <string name="menu_info">Info</string>
     <string name="menu_info_map_file">Kartendatei-Info</string>
     <string name="menu_info_about">Über diese Software</string>
@@ -72,7 +68,6 @@
     <string name="menu_screenshot_jpeg">JPEG (verlustbehaftet)</string>
     <string name="menu_screenshot_png">PNG (verlustlos)</string>
     <string name="no_location_provider_available">Keine Standortquelle verfügbar</string>
-    <!-- 	<string name="ok">OK</string> -->
     <string name="preferences_debug">Entwicklungs-Einstellungen</string>
     <string name="preferences_general">Allgemeine Einstellungen</string>
     <string name="preferences_cache_persistence">Cache-Persistenz</string>

--- a/src/main/res/values-ja/strings_mapsforge.xml
+++ b/src/main/res/values-ja/strings_mapsforge.xml
@@ -26,8 +26,6 @@
     </string-array>
 
     <string name="application_name">Mapsforge</string>
-    <!-- 	<string name="cancel">Cancel</string> -->
-    <!-- 	<string name="error">Error</string> -->
     <string name="error_last_location_unknown">最後の位置が不明です</string>
     <string name="file_invalid">選択したファイルが無効です。</string>
     <string name="file_select">ファイルを選択してください。</string>
@@ -50,8 +48,6 @@
     <string name="info_map_file_start_position">開始位置</string>
     <string name="info_map_file_start_zoom_level">開始ズームレベル</string>
     <string name="info_map_file_version">バージョン</string>
-    <!-- 	<string name="latitude">Latitude</string> -->
-    <!-- 	<string name="longitude">Longitude</string> -->
     <string name="menu_info">情報</string>
     <string name="menu_info_map_file">地図ファイルプロパティ</string>
     <string name="menu_info_about">このソフトウェアについて</string>
@@ -74,7 +70,6 @@
     <string name="menu_screenshot_jpeg">JPEG (ロス有)</string>
     <string name="menu_screenshot_png">PNG (ロスレス)</string>
     <string name="no_location_provider_available">利用できる位置ソースがありません</string>
-    <!-- 	<string name="ok">OK</string> -->
     <string name="preferences_debug">デバッグ設定</string>
     <string name="preferences_general">全般設定</string>
     <string name="preferences_cache_persistence">キャッシュ永続化</string>

--- a/src/main/res/values-nb/strings_mapsforge.xml
+++ b/src/main/res/values-nb/strings_mapsforge.xml
@@ -26,8 +26,6 @@
     </string-array>
 
     <string name="application_name">Mapsforge</string>
-    <!-- 	<string name="cancel">Avbryt</string> -->
-    <!-- 	<string name="error">Feil</string> -->
     <string name="error_last_location_unknown">Siste lokasjon er ukjent</string>
     <string name="file_invalid">Valgt fil er ugyldig.</string>
     <string name="file_select">Venligst velg en fil.</string>
@@ -50,8 +48,6 @@
     <string name="info_map_file_start_position">Start possisjon</string>
     <string name="info_map_file_start_zoom_level">Start zoom nivå</string>
     <string name="info_map_file_version">Versjon</string>
-    <!-- 	<string name="latitude">Breddegrad</string> -->
-    <!-- 	<string name="longitude">Lengdegrad</string> -->
     <string name="menu_info">Info</string>
     <string name="menu_info_map_file">Kart filegenskaper</string>
     <string name="menu_info_about">Om denne programvaren</string>
@@ -74,7 +70,6 @@
     <string name="menu_screenshot_jpeg">JPEG (tapsbasert)</string>
     <string name="menu_screenshot_png">PNG (tapsfri)</string>
     <string name="no_location_provider_available">Ingen posisjonskilde tilgjengelig</string>
-    <!-- 	<string name="ok">OK</string> -->
     <string name="preferences_debug">feilsøkings innstillinger</string>
     <string name="preferences_general">Generelle instillinger</string>
     <string name="preferences_cache_persistence">buffer utholdenhet</string>

--- a/src/main/res/values-sk/strings_mapsforge.xml
+++ b/src/main/res/values-sk/strings_mapsforge.xml
@@ -26,8 +26,6 @@
     </string-array>
 
     <string name="application_name">Mapsforge</string>
-    <!-- 	<string name="cancel">Zrušit</string> -->
-    <!-- 	<string name="error">Chyba</string> -->
     <string name="error_last_location_unknown">Posledná poloha je neznáma</string>
     <string name="file_invalid">Vybraný súbor je neplatný.</string>
     <string name="file_select">Vyberte súbor.</string>
@@ -50,8 +48,6 @@
     <string name="info_map_file_start_position">Počiatočná poloha</string>
     <string name="info_map_file_start_zoom_level">Počiatočné priblíženie</string>
     <string name="info_map_file_version">Verzia</string>
-    <!-- 	<string name="latitude">Zemepisná šírka</string> -->
-    <!-- 	<string name="longitude">Zemepisná dĺžka</string> -->
     <string name="menu_info">Informácie</string>
     <string name="menu_info_map_file">Vlastnosti mapy</string>
     <string name="menu_info_about">O programe</string>
@@ -74,7 +70,6 @@
     <string name="menu_screenshot_jpeg">JPEG (stratová)</string>
     <string name="menu_screenshot_png">PNG (bezstratová)</string>
     <string name="no_location_provider_available">Nie je k dispozícii žiadny poskytovateľ polohy</string>
-    <!-- 	<string name="ok">OK</string> -->
     <string name="preferences_debug">Nastavenie pre vývojára</string>
     <string name="preferences_general">Všeobecné nastavenia</string>
     <string name="preferences_cache_persistence">Platnosť vyrovnávacej pamäte</string>

--- a/src/main/res/values/strings_mapsforge.xml
+++ b/src/main/res/values/strings_mapsforge.xml
@@ -26,8 +26,6 @@
     </string-array>
 
     <string name="application_name">Mapsforge</string>
-    <!-- 	<string name="cancel">Cancel</string> -->
-    <!-- 	<string name="error">Error</string> -->
     <string name="error_last_location_unknown">The last location is unknown</string>
     <string name="file_invalid">The selected file is invalid.</string>
     <string name="file_select">Please select a file.</string>
@@ -50,8 +48,6 @@
     <string name="info_map_file_start_position">Start position</string>
     <string name="info_map_file_start_zoom_level">Start zoom level</string>
     <string name="info_map_file_version">Version</string>
-    <!-- 	<string name="latitude">Latitude</string> -->
-    <!-- 	<string name="longitude">Longitude</string> -->
     <string name="menu_info">Info</string>
     <string name="menu_info_map_file">Map file properties</string>
     <string name="menu_info_about">About this software</string>
@@ -74,7 +70,6 @@
     <string name="menu_screenshot_jpeg">JPEG (lossy)</string>
     <string name="menu_screenshot_png">PNG (lossless)</string>
     <string name="no_location_provider_available">No location source available</string>
-    <!-- 	<string name="ok">OK</string> -->
     <string name="preferences_debug">Debug settings</string>
     <string name="preferences_general">General settings</string>
     <string name="preferences_cache_persistence">Cache persistence</string>


### PR DESCRIPTION
I tested this by changing the `strings.xml` as well as the `strings_mapsforge.xml`, and so I can say that this lines are not needed anymore.
As I commented in my previous PR, it not matter if they are present in one or a other xml, but makes problems if they are present in booth xml files.

all these lines are present alphabetically in `strings.xml` and are not needed anymore in this file.
thanks to @bekuno for reviewing my old PR #89 and for the hint to check other xml
