### PR TITLE
on/off was lost in strings

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -42,8 +42,8 @@
     <string name="gps_enabled">Location enabled</string>
     <string name="gps_fix">Last GPS fix</string>
     <string name="gps_not_enabled_show_system_settings">Location service not enabled. Would you like to show system settings?</string>
-    <string name="gps_off">Location</string>
-    <string name="gps_on">Location</string>
+    <string name="gps_off">Location off</string>
+    <string name="gps_on">Location on</string>
     <string name="info">Information</string>
     <string name="invalid_cartridge">Invalid cartridge\n\n %s</string>
     <string name="invalid_url">Invalid URL</string>


### PR DESCRIPTION
in eebe4c496e68b4719ca523cd606e65ce82989173
some changes from GPS to Location were done.
The on and off text got lost.
Original: GPS On // GPS Off