### PR TITLE
define in app used translations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ android {
         // include only those language resources from libraries that we actively maintain ourselves in the translation project
         // when changed here - also change in array.xml/strings_pref_languages.xml is necessary
         // not yet enough strings translated (>40%): "sl","sv","tr"
-        resConfigs "en","ar","ca","cs","da","de", "el","es","fi","fr","hu","it","ja","ko","nb","nl","pl","pt-rBR","pt-rPT","ru","sk"
+        resConfigs "en","ar","ca","cs","da","de", "el","es","fi","fr","hu","it","ja","ko","nb","nl","pl","pt-rBR","pt-rPT","ru","sk","tr"
     }
 
     // define ndk version to use local the same version as on CI

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ android {
 
         // include only those language resources from libraries that we actively maintain ourselves in the translation project
         // when changed here - also change in array.xml/strings_pref_languages.xml is necessary
-        // not yet enough strings translated (>40%): "sl","sv","tr"
+        // not yet enough strings translated (>40%): "sl","sv"
         resConfigs "en","ar","ca","cs","da","de", "el","es","fi","fr","hu","it","ja","ko","nb","nl","pl","pt-rBR","pt-rPT","ru","sk","tr"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,8 @@ android {
 
         // include only those language resources from libraries that we actively maintain ourselves in the translation project
         // when changed here - also change in array.xml/strings_pref_languages.xml is necessary
-        // not yet enough strings translated (>40%): "sl","sv","tr"
-        resConfigs "en","ar","ca","cs","da","de","el","es","fi","fr","hu","it","ja","ko","nb","nl","pl","pt-rBR","pt-rPT","ru","sk"
+        // not yet enough strings translated (>40%): "sl","sv"
+        resConfigs "en","ar","ca","cs","da","de", "el","es","fi","fr","hu","it","ja","ko","nb","nl","pl","pt-rBR","pt-rPT","ru","sk"
     }
 
     // define ndk version to use local the same version as on CI

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ android {
 
         // include only those language resources from libraries that we actively maintain ourselves in the translation project
         // when changed here - also change in array.xml/strings_pref_languages.xml is necessary
-        // not yet enough strings translated (>40%): "sl","sv"
+        // not yet enough strings translated (>40%): "sl","sv","tr"
         resConfigs "en","ar","ca","cs","da","de", "el","es","fi","fr","hu","it","ja","ko","nb","nl","pl","pt-rBR","pt-rPT","ru","sk"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,11 @@ android {
 
         versionName versionNameFromDate()
         versionCode versionCodeFromDate(0)
+
+        // include only those language resources from libraries that we actively maintain ourselves in the translation project
+        // when changed here - also change in array.xml/strings_pref_languages.xml is necessary
+        // not yet enough strings translated (>40%): "sl","sv","tr"
+        resConfigs "en","ar","ca","cs","da","de","el","es","fi","fr","hu","it","ja","ko","nb","nl","pl","pt-rBR","pt-rPT","ru","sk"
     }
 
     // define ndk version to use local the same version as on CI


### PR DESCRIPTION
fixes #126

Define supported languages based on a fixed list.
This reduces the string resources in the apk to only these languages.
As additional point we need no extra handling for the crowdin export on not yet ready for use languages.