### PR TITLE
Add automatic text scaling on OSM maps (optional) (fix #141)

### DIFF
--- a/src/main/java/menion/android/whereyougo/maps/mapsforge/MapsforgeActivity.java
+++ b/src/main/java/menion/android/whereyougo/maps/mapsforge/MapsforgeActivity.java
@@ -875,7 +875,7 @@ public class MapsforgeActivity extends MapActivity implements IRefreshable {
             this.mapView.setTextScale(Float.parseFloat(sharedPreferences.getString("textScale",
                     textScaleDefault)));
         } catch (NumberFormatException e) {
-            this.mapView.setTextScale(1);
+            this.mapView.setTextScale(getResources().getDisplayMetrics().density);
         }
 
         if (sharedPreferences.getBoolean("fullscreen", false)) {

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -12,6 +12,7 @@
         <item>1.0</item>
         <item>1.3</item>
         <item>1.6</item>
+        <item>automatic</item>
     </string-array>
     <string name="preferences_text_scale_default" translatable="false">1.0</string>
 

--- a/src/main/res/values/strings_mapsforge.xml
+++ b/src/main/res/values/strings_mapsforge.xml
@@ -12,6 +12,7 @@
         <item>normal</item>
         <item>large</item>
         <item>huge</item>
+        <item>automatic</item>
     </string-array>
 
     <string-array name="mapgenerator_values">


### PR DESCRIPTION
- add map preferences option to set text scaling to automatic
- if set to automatic, set text scaling on offline OSM maps according to screen density

Added map preference value "automatic" for text size:
![image](https://user-images.githubusercontent.com/3754370/79068838-25f0d680-7cca-11ea-9231-c4af1a2fe715.png)

Resulting map view:
![image](https://user-images.githubusercontent.com/3754370/79068832-1d989b80-7cca-11ea-88bd-8c79b2662774.png)

