### PR TITLE
beautify tile caching 

### DIFF
--- a/src/main/java/menion/android/whereyougo/maps/mapsforge/MapsforgeActivity.java
+++ b/src/main/java/menion/android/whereyougo/maps/mapsforge/MapsforgeActivity.java
@@ -889,9 +889,9 @@ public class MapsforgeActivity extends MapActivity implements IRefreshable {
             this.wakeLock.acquire();
         }
 
-        boolean persistent = sharedPreferences.getBoolean("cachePersistence", false);
+        boolean persistent = sharedPreferences.getBoolean("tileCachePersistence", true);
         int capacity =
-                Math.min(sharedPreferences.getInt("cacheSize", FILE_SYSTEM_CACHE_SIZE_DEFAULT),
+                Math.min(sharedPreferences.getInt("tileCacheSize", FILE_SYSTEM_CACHE_SIZE_DEFAULT),
                         FILE_SYSTEM_CACHE_SIZE_MAX);
         TileCache fileSystemTileCache = this.mapView.getFileSystemTileCache();
         fileSystemTileCache.setPersistent(persistent);

--- a/src/main/java/menion/android/whereyougo/maps/mapsforge/MapsforgeActivity.java
+++ b/src/main/java/menion/android/whereyougo/maps/mapsforge/MapsforgeActivity.java
@@ -110,14 +110,14 @@ import menion.android.whereyougo.utils.UtilsFormat;
  */
 public class MapsforgeActivity extends MapActivity implements IRefreshable {
     /**
-     * The default number of tiles in the file system cache.
+     * The default number of tiles in the file system cache. (229 = 30 MB)
      */
-    public static final int FILE_SYSTEM_CACHE_SIZE_DEFAULT = 250;
+    public static final int FILE_SYSTEM_CACHE_SIZE_DEFAULT = 229;
 
     /**
-     * The maximum number of tiles in the file system cache.
+     * The maximum number of tiles in the file system cache. (381 = 50 MB)
      */
-    public static final int FILE_SYSTEM_CACHE_SIZE_MAX = 500;
+    public static final int FILE_SYSTEM_CACHE_SIZE_MAX = 381;
 
     /**
      * The default move speed factor of the map.

--- a/src/main/java/menion/android/whereyougo/maps/mapsforge/MapsforgeActivity.java
+++ b/src/main/java/menion/android/whereyougo/maps/mapsforge/MapsforgeActivity.java
@@ -115,9 +115,9 @@ public class MapsforgeActivity extends MapActivity implements IRefreshable {
     public static final int FILE_SYSTEM_CACHE_SIZE_DEFAULT = 229;
 
     /**
-     * The maximum number of tiles in the file system cache. (381 = 50 MB)
+     * The maximum number of tiles in the file system cache. (458 = 60 MB)
      */
-    public static final int FILE_SYSTEM_CACHE_SIZE_MAX = 381;
+    public static final int FILE_SYSTEM_CACHE_SIZE_MAX = 458;
 
     /**
      * The default move speed factor of the map.

--- a/src/main/java/menion/android/whereyougo/maps/mapsforge/preferences/CacheSizePreference.java
+++ b/src/main/java/menion/android/whereyougo/maps/mapsforge/preferences/CacheSizePreference.java
@@ -38,7 +38,7 @@ public class CacheSizePreference extends SeekBarPreference {
     public CacheSizePreference(Context context, AttributeSet attrs) {
         super(context, attrs);
         // define the text message
-        this.messageText = getContext().getString(R.string.preferences_cache_size_desc);
+        this.messageText = getContext().getString(R.string.preferences_tileCache_size_desc);
 
         // define the current and maximum value of the seek bar
         this.seekBarCurrentValue =
@@ -49,7 +49,7 @@ public class CacheSizePreference extends SeekBarPreference {
 
     @Override
     String getCurrentValueText(int progress) {
-        String format = getContext().getString(R.string.preferences_cache_size_value);
+        String format = getContext().getString(R.string.preferences_tileCache_size_value);
         Double value = TILE_SIZE_IN_BYTES * progress / ONE_MEGABYTE;
         return String.format(format, value);
     }

--- a/src/main/res/values/strings_mapsforge.xml
+++ b/src/main/res/values/strings_mapsforge.xml
@@ -72,11 +72,12 @@
     <string name="no_location_provider_available">No location source available</string>
     <string name="preferences_debug">Debug settings</string>
     <string name="preferences_general">General settings</string>
-    <string name="preferences_cache_persistence">Cache persistence</string>
-    <string name="preferences_cache_persistence_desc">Keep cached images on exit</string>
-    <string name="preferences_cache_size">External storage</string>
-    <string name="preferences_cache_size_desc">Adjust the size of the cache</string>
-    <string name="preferences_cache_size_value">%.1f MB</string>
+    <string name="preferences_tileCache">Map tile cache settings</string>
+    <string name="preferences_tileCache_persistence">Tile cache persistence</string>
+    <string name="preferences_tileCache_persistence_desc">Keep cached images on exit</string>
+    <string name="preferences_tileCache_size">Tile cache size</string>
+    <string name="preferences_tileCache_size_desc">Adjust the size of the tile cache</string>
+    <string name="preferences_tileCache_size_value">%.1f MB</string>
     <string name="preferences_fullscreen">Full screen mode</string>
     <string name="preferences_fullscreen_desc">Hide the status bar</string>
     <string name="preferences_map">Map settings</string>

--- a/src/main/res/xml/mapsforge_preferences.xml
+++ b/src/main/res/xml/mapsforge_preferences.xml
@@ -32,18 +32,22 @@
             android:key="wakeLock"
             android:summary="@string/preferences_wake_lock_desc"
             android:title="@string/preferences_wake_lock" />
-        <CheckBoxPreference
-            android:key="cachePersistence"
-            android:summary="@string/preferences_cache_persistence_desc"
-            android:title="@string/preferences_cache_persistence" />
-        <menion.android.whereyougo.maps.mapsforge.preferences.CacheSizePreference
-            android:key="cacheSize"
-            android:summary="@string/preferences_cache_size_desc"
-            android:title="@string/preferences_cache_size" />
         <menion.android.whereyougo.maps.mapsforge.preferences.MoveSpeedPreference
             android:key="moveSpeed"
             android:summary="@string/preferences_move_speed_desc"
             android:title="@string/preferences_move_speed" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/preferences_tileCache">
+        <menion.android.whereyougo.maps.mapsforge.preferences.CacheSizePreference
+            android:key="tileCacheSize"
+            android:summary="@string/preferences_tileCache_size_desc"
+            android:title="@string/preferences_tileCache_size" />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="tileCachePersistence"
+            android:summary="@string/preferences_tileCache_persistence_desc"
+            android:title="@string/preferences_tileCache_persistence" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/preferences_debug">


### PR DESCRIPTION
As discussed in PR cgeo#129 the options for tile caching are false translated and not good sorted in the settings.
Therefore changed
- own group in settings for tile caching
- rename the id's for the tile cache parameter for better understanding
- rename the strings
- set tile cache persistence initial to true