### PR TITLE
Improve password usability experience

### DIFF
--- a/src/main/java/menion/android/whereyougo/gui/dialog/NoPasswordDialogFragment.java
+++ b/src/main/java/menion/android/whereyougo/gui/dialog/NoPasswordDialogFragment.java
@@ -1,0 +1,34 @@
+package menion.android.whereyougo.gui.dialog;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+
+import androidx.fragment.app.DialogFragment;
+
+import menion.android.whereyougo.R;
+
+public class NoPasswordDialogFragment extends DialogFragment {
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        // Use the Builder class for convenient dialog construction
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setMessage(R.string.dialog_no_password)
+                .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        // FIRE ZE MISSILES!
+                    }
+                })
+                .setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        // User cancelled the dialog
+                    }
+                });
+        // Create the AlertDialog object and return it
+        return builder.create();
+    }
+
+
+}

--- a/src/main/java/menion/android/whereyougo/gui/dialog/NoPasswordDialogFragment.java
+++ b/src/main/java/menion/android/whereyougo/gui/dialog/NoPasswordDialogFragment.java
@@ -13,9 +13,20 @@ import menion.android.whereyougo.R;
 public class NoPasswordDialogFragment extends DialogFragment {
 
     private NoPasswordDialogListener listener;
+    private int message;
 
     public interface NoPasswordDialogListener {
         void onPositiveClick(DialogFragment dialog);
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            message = getArguments().getInt("message");
+        } else {
+            throw new IllegalArgumentException("This dialog needs to be handed a Bundle as an arguement with the key \"message\" which is a Android string resource int.");
+        }
     }
 
     @Override
@@ -34,7 +45,7 @@ public class NoPasswordDialogFragment extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         // Use the Builder class for convenient dialog construction
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        builder.setMessage(R.string.dialog_no_password)
+        builder.setMessage(message)
                 .setPositiveButton(R.string.ok, (dialog, id) -> listener.onPositiveClick(NoPasswordDialogFragment.this))
                 .setNegativeButton(R.string.cancel, (dialog, id) -> {
                     // User cancelled the dialog --> Do nothing

--- a/src/main/java/menion/android/whereyougo/gui/dialog/NoPasswordDialogFragment.java
+++ b/src/main/java/menion/android/whereyougo/gui/dialog/NoPasswordDialogFragment.java
@@ -3,9 +3,9 @@ package menion.android.whereyougo.gui.dialog;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
 
 import menion.android.whereyougo.R;
@@ -15,7 +15,7 @@ public class NoPasswordDialogFragment extends DialogFragment {
     private NoPasswordDialogListener listener;
 
     public interface NoPasswordDialogListener {
-        public void onPositiveClick(DialogFragment dialog);
+        void onPositiveClick(DialogFragment dialog);
     }
 
     @Override
@@ -29,24 +29,17 @@ public class NoPasswordDialogFragment extends DialogFragment {
         }
     }
 
+    @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         // Use the Builder class for convenient dialog construction
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setMessage(R.string.dialog_no_password)
-                .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
-                        listener.onPositiveClick(NoPasswordDialogFragment.this);
-                    }
-                })
-                .setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
-                        // User cancelled the dialog --> Do nothing
-                    }
+                .setPositiveButton(R.string.ok, (dialog, id) -> listener.onPositiveClick(NoPasswordDialogFragment.this))
+                .setNegativeButton(R.string.cancel, (dialog, id) -> {
+                    // User cancelled the dialog --> Do nothing
                 });
         // Create the AlertDialog object and return it
         return builder.create();
     }
-
-
 }

--- a/src/main/java/menion/android/whereyougo/gui/dialog/NoPasswordDialogFragment.java
+++ b/src/main/java/menion/android/whereyougo/gui/dialog/NoPasswordDialogFragment.java
@@ -15,7 +15,7 @@ public class NoPasswordDialogFragment extends DialogFragment {
     private NoPasswordDialogListener listener;
 
     public interface NoPasswordDialogListener {
-        public void onNeutralClick(DialogFragment dialog);
+        public void onPositiveClick(DialogFragment dialog);
     }
 
     @Override
@@ -36,18 +36,12 @@ public class NoPasswordDialogFragment extends DialogFragment {
         builder.setMessage(R.string.dialog_no_password)
                 .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
-                        // FIRE ZE MISSILES!
-                    }
-                })
-                .setNeutralButton(R.string.settings, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialogInterface, int i) {
-                        listener.onNeutralClick(NoPasswordDialogFragment.this);
+                        listener.onPositiveClick(NoPasswordDialogFragment.this);
                     }
                 })
                 .setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
-                        // User cancelled the dialog
+                        // User cancelled the dialog --> Do nothing
                     }
                 });
         // Create the AlertDialog object and return it

--- a/src/main/java/menion/android/whereyougo/gui/dialog/NoPasswordDialogFragment.java
+++ b/src/main/java/menion/android/whereyougo/gui/dialog/NoPasswordDialogFragment.java
@@ -2,14 +2,35 @@ package menion.android.whereyougo.gui.dialog;
 
 import android.app.AlertDialog;
 import android.app.Dialog;
+import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.os.Bundle;
 
 import androidx.fragment.app.DialogFragment;
 
 import menion.android.whereyougo.R;
+import menion.android.whereyougo.gui.activity.XmlSettingsActivity;
+import menion.android.whereyougo.network.activity.DownloadCartridgeActivity;
 
 public class NoPasswordDialogFragment extends DialogFragment {
+
+    public interface NoPasswordDialogListener {
+        public void onNeutralClick(DialogFragment dialog);
+    }
+
+    NoPasswordDialogListener listener;
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+
+        try {
+            listener = (NoPasswordDialogListener) context;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(getActivity().toString() + "must implement NoPasswordDialogListener.");
+        }
+    }
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
@@ -19,6 +40,12 @@ public class NoPasswordDialogFragment extends DialogFragment {
                 .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         // FIRE ZE MISSILES!
+                    }
+                })
+                .setNeutralButton(R.string.settings, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        listener.onNeutralClick(NoPasswordDialogFragment.this);
                     }
                 })
                 .setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {

--- a/src/main/java/menion/android/whereyougo/gui/dialog/NoPasswordDialogFragment.java
+++ b/src/main/java/menion/android/whereyougo/gui/dialog/NoPasswordDialogFragment.java
@@ -4,22 +4,19 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.Intent;
 import android.os.Bundle;
 
 import androidx.fragment.app.DialogFragment;
 
 import menion.android.whereyougo.R;
-import menion.android.whereyougo.gui.activity.XmlSettingsActivity;
-import menion.android.whereyougo.network.activity.DownloadCartridgeActivity;
 
 public class NoPasswordDialogFragment extends DialogFragment {
+
+    private NoPasswordDialogListener listener;
 
     public interface NoPasswordDialogListener {
         public void onNeutralClick(DialogFragment dialog);
     }
-
-    NoPasswordDialogListener listener;
 
     @Override
     public void onAttach(Context context) {

--- a/src/main/java/menion/android/whereyougo/gui/dialog/PositiveButtonActionCustomizableDialogFragment.java
+++ b/src/main/java/menion/android/whereyougo/gui/dialog/PositiveButtonActionCustomizableDialogFragment.java
@@ -25,32 +25,35 @@ public class PositiveButtonActionCustomizableDialogFragment extends DialogFragme
         if (getArguments() != null) {
             message = getArguments().getInt("message");
         } else {
-            throw new IllegalArgumentException("This dialog needs to be handed a Bundle as an arguement with the key \"message\" which is a Android string resource int.");
+            throw new IllegalArgumentException("This dialog needs to be handed a Bundle as an "
+                    + "argument with the key \"message\" which is a Android string resource int.");
         }
     }
 
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-
         try {
             listener = (PositiveButtonActionCustomizableDialogListener) context;
         } catch (ClassCastException e) {
-            throw new ClassCastException(getActivity().toString() + "must implement NoPasswordDialogListener.");
+            String exceptionDescription = String.format("%s must implement "
+                            + "PositiveButtonActionCustomizableDialogListener.",
+                    getActivity().toString());
+            throw new ClassCastException(exceptionDescription);
         }
     }
 
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        // Use the Builder class for convenient dialog construction
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setMessage(message)
-                .setPositiveButton(R.string.ok, (dialog, id) -> listener.onPositiveClick(PositiveButtonActionCustomizableDialogFragment.this))
+                .setPositiveButton(R.string.ok, (dialog, id) ->
+                        listener.onPositiveClick(
+                                PositiveButtonActionCustomizableDialogFragment.this))
                 .setNegativeButton(R.string.cancel, (dialog, id) -> {
                     // User cancelled the dialog --> Do nothing
                 });
-        // Create the AlertDialog object and return it
         return builder.create();
     }
 }

--- a/src/main/java/menion/android/whereyougo/gui/dialog/PositiveButtonActionCustomizableDialogFragment.java
+++ b/src/main/java/menion/android/whereyougo/gui/dialog/PositiveButtonActionCustomizableDialogFragment.java
@@ -10,12 +10,12 @@ import androidx.fragment.app.DialogFragment;
 
 import menion.android.whereyougo.R;
 
-public class NoPasswordDialogFragment extends DialogFragment {
+public class PositiveButtonActionCustomizableDialogFragment extends DialogFragment {
 
-    private NoPasswordDialogListener listener;
+    private PositiveButtonActionCustomizableDialogListener listener;
     private int message;
 
-    public interface NoPasswordDialogListener {
+    public interface PositiveButtonActionCustomizableDialogListener {
         void onPositiveClick(DialogFragment dialog);
     }
 
@@ -34,7 +34,7 @@ public class NoPasswordDialogFragment extends DialogFragment {
         super.onAttach(context);
 
         try {
-            listener = (NoPasswordDialogListener) context;
+            listener = (PositiveButtonActionCustomizableDialogListener) context;
         } catch (ClassCastException e) {
             throw new ClassCastException(getActivity().toString() + "must implement NoPasswordDialogListener.");
         }
@@ -46,7 +46,7 @@ public class NoPasswordDialogFragment extends DialogFragment {
         // Use the Builder class for convenient dialog construction
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setMessage(message)
-                .setPositiveButton(R.string.ok, (dialog, id) -> listener.onPositiveClick(NoPasswordDialogFragment.this))
+                .setPositiveButton(R.string.ok, (dialog, id) -> listener.onPositiveClick(PositiveButtonActionCustomizableDialogFragment.this))
                 .setNegativeButton(R.string.cancel, (dialog, id) -> {
                     // User cancelled the dialog --> Do nothing
                 });

--- a/src/main/java/menion/android/whereyougo/network/activity/DownloadCartridgeActivity.java
+++ b/src/main/java/menion/android/whereyougo/network/activity/DownloadCartridgeActivity.java
@@ -38,7 +38,7 @@ import java.io.File;
 import menion.android.whereyougo.R;
 import menion.android.whereyougo.gui.activity.MainActivity;
 import menion.android.whereyougo.gui.activity.XmlSettingsActivity;
-import menion.android.whereyougo.gui.dialog.NoPasswordDialogFragment;
+import menion.android.whereyougo.gui.dialog.PositiveButtonActionCustomizableDialogFragment;
 import menion.android.whereyougo.gui.extension.activity.CustomActivity;
 import menion.android.whereyougo.gui.extension.dialog.CustomDialog;
 import menion.android.whereyougo.network.DownloadCartridgeTask;
@@ -49,7 +49,7 @@ import menion.android.whereyougo.utils.ManagerNotify;
 import menion.android.whereyougo.utils.UtilsFormat;
 
 public class DownloadCartridgeActivity extends CustomActivity
-        implements NoPasswordDialogFragment.NoPasswordDialogListener {
+        implements PositiveButtonActionCustomizableDialogFragment.PositiveButtonActionCustomizableDialogListener {
     private static final String TAG = "DownloadCartridgeAct";
     private DownloadCartridgeTask downloadTask;
     private String cguid;
@@ -135,9 +135,9 @@ public class DownloadCartridgeActivity extends CustomActivity
         if (checkEmptyUsernamePassword()) {
             Bundle args = new Bundle();
             args.putInt("message", R.string.dialog_no_password);
-            NoPasswordDialogFragment noPasswordDialogFragment = new NoPasswordDialogFragment();
-            noPasswordDialogFragment.setArguments(args);
-            noPasswordDialogFragment.show(getSupportFragmentManager(), "NoUsernameOrPassword");
+            PositiveButtonActionCustomizableDialogFragment positiveButtonActionCustomizableDialogFragment = new PositiveButtonActionCustomizableDialogFragment();
+            positiveButtonActionCustomizableDialogFragment.setArguments(args);
+            positiveButtonActionCustomizableDialogFragment.show(getSupportFragmentManager(), "NoUsernameOrPassword");
         }
     }
 
@@ -253,9 +253,9 @@ public class DownloadCartridgeActivity extends CustomActivity
                     if (progress.getState() == State.FAIL) {
                         Bundle args = new Bundle();
                         args.putInt("message", R.string.dialog_wrong_credentials);
-                        NoPasswordDialogFragment noPasswordDialogFragment = new NoPasswordDialogFragment();
-                        noPasswordDialogFragment.setArguments(args);
-                        noPasswordDialogFragment.show(getSupportFragmentManager(), "NoUsernameOrPassword");
+                        PositiveButtonActionCustomizableDialogFragment positiveButtonActionCustomizableDialogFragment = new PositiveButtonActionCustomizableDialogFragment();
+                        positiveButtonActionCustomizableDialogFragment.setArguments(args);
+                        positiveButtonActionCustomizableDialogFragment.show(getSupportFragmentManager(), "NoUsernameOrPassword");
                     }
                     break;
                 case LOGOUT:

--- a/src/main/java/menion/android/whereyougo/network/activity/DownloadCartridgeActivity.java
+++ b/src/main/java/menion/android/whereyougo/network/activity/DownloadCartridgeActivity.java
@@ -63,10 +63,18 @@ public class DownloadCartridgeActivity extends CustomActivity {
             return;
         }
 
+        String username = Preferences.GC_USERNAME;
+        String password = Preferences.GC_PASSWORD;
+
         setContentView(R.layout.layout_details);
 
         TextView tvName = (TextView) findViewById(R.id.layoutDetailsTextViewName);
         tvName.setText(R.string.download_cartridge);
+        Button buttonDownload = (Button) findViewById(R.id.button_positive);
+        Button buttonStart = (Button) findViewById(R.id.button_negative);
+        // If one of the variables is empty the inner condition is true which get's negated because
+        // the button get's enabled on true and disabled on false.
+        buttonDownload.setEnabled(!(username.isEmpty() && password.isEmpty()));
 
         TextView tvDescription = (TextView) findViewById(R.id.layoutDetailsTextViewDescription);
         TextView tvState = (TextView) findViewById(R.id.layoutDetailsTextViewState);
@@ -102,8 +110,6 @@ public class DownloadCartridgeActivity extends CustomActivity {
                     downloadTask.cancel(true);
                     downloadTask = null;
                 } else {
-                    String username = Preferences.GC_USERNAME;
-                    String password = Preferences.GC_PASSWORD;
                     downloadTask = new DownloadTask(DownloadCartridgeActivity.this, username, password);
                     downloadTask.execute(cguid);
                 }
@@ -121,8 +127,6 @@ public class DownloadCartridgeActivity extends CustomActivity {
                 return true;
             }
         });
-        Button buttonDownload = (Button) findViewById(R.id.button_positive);
-        Button buttonStart = (Button) findViewById(R.id.button_negative);
         buttonStart.setEnabled(cartridgeFile != null);
     }
 

--- a/src/main/java/menion/android/whereyougo/network/activity/DownloadCartridgeActivity.java
+++ b/src/main/java/menion/android/whereyougo/network/activity/DownloadCartridgeActivity.java
@@ -1,14 +1,14 @@
 /*
  * Copyright 2014 biylda <biylda@gmail.com>
- * 
+ *
  * This program is free software: you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program. If not,
  * see <http://www.gnu.org/licenses/>.
  */
@@ -31,6 +31,8 @@ import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.fragment.app.DialogFragment;
+
 import java.io.File;
 
 import menion.android.whereyougo.R;
@@ -46,7 +48,8 @@ import menion.android.whereyougo.utils.Images;
 import menion.android.whereyougo.utils.ManagerNotify;
 import menion.android.whereyougo.utils.UtilsFormat;
 
-public class DownloadCartridgeActivity extends CustomActivity {
+public class DownloadCartridgeActivity extends CustomActivity
+        implements NoPasswordDialogFragment.NoPasswordDialogListener {
     private static final String TAG = "DownloadCartridgeActivity";
     private DownloadCartridgeTask downloadTask;
     private String cguid;
@@ -147,6 +150,13 @@ public class DownloadCartridgeActivity extends CustomActivity {
         }
     }
 
+    @Override
+    public void onNeutralClick(DialogFragment dialog) {
+        Intent loginPreferenceIntent = new Intent(DownloadCartridgeActivity.this, XmlSettingsActivity.class);
+        loginPreferenceIntent.putExtra(getString(R.string.pref_KEY_X_LOGIN_PREFERENCES), true);
+        startActivity(loginPreferenceIntent);
+    }
+
     class DownloadTask extends DownloadCartridgeTask {
         final ProgressDialog progressDialog;
 
@@ -202,7 +212,7 @@ public class DownloadCartridgeActivity extends CustomActivity {
             if (progress.getState() == State.SUCCESS) {
                 suffix = String.format(": %s", getString(R.string.ok));
             } else if (progress.getState() == State.FAIL) {
-                if (progress.getMessage() == null){
+                if (progress.getMessage() == null) {
                     suffix = String.format(": %s", getString(R.string.error));
                 } else {
                     suffix = String.format(": %s(%s)", getString(R.string.error), progress.getMessage());

--- a/src/main/java/menion/android/whereyougo/network/activity/DownloadCartridgeActivity.java
+++ b/src/main/java/menion/android/whereyougo/network/activity/DownloadCartridgeActivity.java
@@ -36,6 +36,7 @@ import java.io.File;
 import menion.android.whereyougo.R;
 import menion.android.whereyougo.gui.activity.MainActivity;
 import menion.android.whereyougo.gui.activity.XmlSettingsActivity;
+import menion.android.whereyougo.gui.dialog.NoPasswordDialogFragment;
 import menion.android.whereyougo.gui.extension.activity.CustomActivity;
 import menion.android.whereyougo.gui.extension.dialog.CustomDialog;
 import menion.android.whereyougo.network.DownloadCartridgeTask;
@@ -74,7 +75,8 @@ public class DownloadCartridgeActivity extends CustomActivity {
         Button buttonStart = (Button) findViewById(R.id.button_negative);
         // If one of the variables is empty the inner condition is true which get's negated because
         // the button get's enabled on true and disabled on false.
-        buttonDownload.setEnabled(!(username.isEmpty() && password.isEmpty()));
+        boolean emptyUsernameOrPassword = username.isEmpty() || password.isEmpty();
+        buttonDownload.setEnabled(!emptyUsernameOrPassword);
 
         TextView tvDescription = (TextView) findViewById(R.id.layoutDetailsTextViewDescription);
         TextView tvState = (TextView) findViewById(R.id.layoutDetailsTextViewState);
@@ -128,6 +130,11 @@ public class DownloadCartridgeActivity extends CustomActivity {
             }
         });
         buttonStart.setEnabled(cartridgeFile != null);
+
+        if (emptyUsernameOrPassword) {
+            NoPasswordDialogFragment noPasswordDialogFragment = new NoPasswordDialogFragment();
+            noPasswordDialogFragment.show(getSupportFragmentManager(), "NoUsernameOrPassword");
+        }
     }
 
     @Override

--- a/src/main/java/menion/android/whereyougo/network/activity/DownloadCartridgeActivity.java
+++ b/src/main/java/menion/android/whereyougo/network/activity/DownloadCartridgeActivity.java
@@ -17,7 +17,6 @@ package menion.android.whereyougo.network.activity;
 
 import android.app.ProgressDialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
@@ -192,16 +191,12 @@ public class DownloadCartridgeActivity extends CustomActivity
             progressDialog.setCanceledOnTouchOutside(false);
 
             progressDialog.setCancelable(true);
-            progressDialog.setOnCancelListener(new ProgressDialog.OnCancelListener() {
-
-                @Override
-                public void onCancel(DialogInterface arg0) {
-                    if (downloadTask != null && downloadTask.getStatus() != Status.FINISHED) {
-                        downloadTask.cancel(false);
-                        downloadTask = null;
-                        Log.i("down", "cancel");
-                        ManagerNotify.toastShortMessage(context, getString(R.string.cancelled));
-                    }
+            progressDialog.setOnCancelListener(arg0 -> {
+                if (downloadTask != null && downloadTask.getStatus() != Status.FINISHED) {
+                    downloadTask.cancel(false);
+                    downloadTask = null;
+                    Log.i("down", "cancel");
+                    ManagerNotify.toastShortMessage(context, getString(R.string.cancelled));
                 }
             });
         }

--- a/src/main/java/menion/android/whereyougo/network/activity/DownloadCartridgeActivity.java
+++ b/src/main/java/menion/android/whereyougo/network/activity/DownloadCartridgeActivity.java
@@ -151,7 +151,7 @@ public class DownloadCartridgeActivity extends CustomActivity
     }
 
     @Override
-    public void onNeutralClick(DialogFragment dialog) {
+    public void onPositiveClick(DialogFragment dialog) {
         Intent loginPreferenceIntent = new Intent(DownloadCartridgeActivity.this, XmlSettingsActivity.class);
         loginPreferenceIntent.putExtra(getString(R.string.pref_KEY_X_LOGIN_PREFERENCES), true);
         startActivity(loginPreferenceIntent);

--- a/src/main/java/menion/android/whereyougo/network/activity/DownloadCartridgeActivity.java
+++ b/src/main/java/menion/android/whereyougo/network/activity/DownloadCartridgeActivity.java
@@ -50,11 +50,10 @@ import menion.android.whereyougo.utils.UtilsFormat;
 
 public class DownloadCartridgeActivity extends CustomActivity
         implements PositiveButtonActionCustomizableDialogFragment.PositiveButtonActionCustomizableDialogListener {
-    private static final String TAG = "DownloadCartridgeAct";
     private DownloadCartridgeTask downloadTask;
     private String cguid;
-    private String Username;
-    private String Password;
+    private String username;
+    private String password;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -69,8 +68,8 @@ public class DownloadCartridgeActivity extends CustomActivity
             return;
         }
 
-        Username = Preferences.GC_USERNAME;
-        Password = Preferences.GC_PASSWORD;
+        username = Preferences.GC_USERNAME;
+        password = Preferences.GC_PASSWORD;
 
         setContentView(R.layout.layout_details);
 
@@ -113,7 +112,7 @@ public class DownloadCartridgeActivity extends CustomActivity
                     downloadTask.cancel(true);
                     downloadTask = null;
                 } else {
-                    downloadTask = new DownloadTask(DownloadCartridgeActivity.this, Username, Password);
+                    downloadTask = new DownloadTask(DownloadCartridgeActivity.this, username, password);
                     downloadTask.execute(cguid);
                 }
                 return true;
@@ -144,8 +143,8 @@ public class DownloadCartridgeActivity extends CustomActivity
     @Override
     public void onResume() {
         super.onResume();
-        Username = Preferences.GC_USERNAME;
-        Password = Preferences.GC_PASSWORD;
+        username = Preferences.GC_USERNAME;
+        password = Preferences.GC_PASSWORD;
         adjustDownloadButtonToUsernamePasswordState();
     }
 
@@ -160,7 +159,7 @@ public class DownloadCartridgeActivity extends CustomActivity
     }
 
     /**
-     * This method implements the Interface "NoPasswordDialogListener".
+     * This method implements the Interface "PositiveButtonActionCustomizableDialogListener".
      */
     @Override
     public void onPositiveClick(DialogFragment dialog) {
@@ -177,7 +176,7 @@ public class DownloadCartridgeActivity extends CustomActivity
     }
 
     private boolean checkEmptyUsernamePassword() {
-        return Username.isEmpty() || Password.isEmpty();
+        return username.isEmpty() || password.isEmpty();
     }
 
     class DownloadTask extends DownloadCartridgeTask {
@@ -256,6 +255,7 @@ public class DownloadCartridgeActivity extends CustomActivity
                         PositiveButtonActionCustomizableDialogFragment positiveButtonActionCustomizableDialogFragment = new PositiveButtonActionCustomizableDialogFragment();
                         positiveButtonActionCustomizableDialogFragment.setArguments(args);
                         positiveButtonActionCustomizableDialogFragment.show(getSupportFragmentManager(), "NoUsernameOrPassword");
+                        progressDialog.cancel();
                     }
                     break;
                 case LOGOUT:

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -122,6 +122,6 @@
     <string name="location_permission_request_explanation">WhereYouGo needs access to the GPS on your device to locate your position and calculate distance and direction to the Cartridge locations.</string>
     <string name="storage_permission_request_explanation">WhereYouGo will write data onto your phone storage or SD card as soon as you save the Cartridge.</string>
     <string name="permission_conclusion">The app cannot be used without this permission(s).</string>
-    <string name="dialog_no_password">You havn\'t configured a password and/or username! Please do so in the WhereYouGo Settings. Click OK to open the WhereYouGo settings now. Click Cancel to close this dialog and return to the previous screen.</string>
+    <string name="dialog_no_password">You have not configured your user name and/or password! Please do so in the WhereYouGo Settings. Click OK to open the WhereYouGo settings now. Click Cancel to close this dialog and return to the previous screen.</string>
 
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -122,5 +122,6 @@
     <string name="location_permission_request_explanation">WhereYouGo needs access to the GPS on your device to locate your position and calculate distance and direction to the Cartridge locations.</string>
     <string name="storage_permission_request_explanation">WhereYouGo will write data onto your phone storage or SD card as soon as you save the Cartridge.</string>
     <string name="permission_conclusion">The app cannot be used without this permission(s).</string>
+    <string name="dialog_no_password">You havn\'t configured a password and/or username! Please do so in the WhereYouGo Settings.</string>
 
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -123,5 +123,6 @@
     <string name="storage_permission_request_explanation">WhereYouGo will write data onto your phone storage or SD card as soon as you save the Cartridge.</string>
     <string name="permission_conclusion">The app cannot be used without this permission(s).</string>
     <string name="dialog_no_password">You have not configured your user name and/or password! Please do so in the WhereYouGo Settings. Click OK to open the WhereYouGo settings now. Click Cancel to close this dialog and return to the previous screen.</string>
+    <string name="dialog_wrong_credentials">The download of the cartridge has failed. This may be due to wrong credentials or due to connection problems. Click OK to open the WhereYouGo settings now. Click Cancel to close this dialog and return to the previous screen.</string>
 
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -122,6 +122,6 @@
     <string name="location_permission_request_explanation">WhereYouGo needs access to the GPS on your device to locate your position and calculate distance and direction to the Cartridge locations.</string>
     <string name="storage_permission_request_explanation">WhereYouGo will write data onto your phone storage or SD card as soon as you save the Cartridge.</string>
     <string name="permission_conclusion">The app cannot be used without this permission(s).</string>
-    <string name="dialog_no_password">You havn\'t configured a password and/or username! Please do so in the WhereYouGo Settings.</string>
+    <string name="dialog_no_password">You havn\'t configured a password and/or username! Please do so in the WhereYouGo Settings. Click OK to open the WhereYouGo settings now. Click Cancel to close this dialog and return to the previous screen.</string>
 
 </resources>


### PR DESCRIPTION
This PR aims to close #11 

It should resolve the following usability issues:

- Hint for a user if the password is invalid (maybe a password change)
- Hint for a user if the password is empty (after inital WhereYouGo download)