### PR TITLE
restore mapfile/mapgenerator only if non empty (fix #201)

### DIFF
--- a/src/main/java/menion/android/whereyougo/maps/mapsforge/MapsforgeActivity.java
+++ b/src/main/java/menion/android/whereyougo/maps/mapsforge/MapsforgeActivity.java
@@ -988,7 +988,7 @@ public class MapsforgeActivity extends MapActivity implements IRefreshable {
                 FileOpenResult result = mapView.setMapFile(new File(newMapfile));
                 if (result == FileOpenResult.SUCCESS) {
                     setMapGenerator(MapGeneratorInternal.DATABASE_RENDERER);
-                } else {
+                } else if (null != backupMapFile && null != backupMapGenerator) {
                     // restore the backuped data
                     mapView.setMapFile(backupMapFile);
                     mapView.setMapGenerator(backupMapGenerator);


### PR DESCRIPTION
Fixes the error, that if the currently set map was no OSM offline map, WhereYouGo crashed on map start.