### PR TITLE
Crowdin merge strategy release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# For translated strings we do not want automatic merging between branches as Crowdin will deliver translations to each branch as needed
+# Including these files when merging branches would often result in conflicts as we receive regular changes on both branches from Crowdin
+# The merge strategy ours is a dummy merge strategy only returning "true" as defined in .gitconfig for this repository.
+# This will result in the files mentioned here not being processed during merge
+
+# Ignore translated strings
+/src/main/res/values-*/strings.xml merge=ours
+/src/main/res/values-*/strings_mapsforge.xml merge=ours
+
+# Ignore translated playstore description 
+/_data/playstore/translated/* merge=ours

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,9 @@
+# Merge strategy "ours" is a dummy merge strategy only returning "true" which means files using this merge strategy will not be processed in case of merging, except if fast forwarding is applied.
+# For translated strings we do not want automatic merging between branches as Crowdin will deliver translations to each branch as needed.
+# Including these files when merging branches would often result in merge conflicts as we receive regular changes on both branches from Crowdin.
+# IMPORTANT: 
+# In order to make use of this config after you cloned the c:geo repository you need to apply the following command on your local c:geo repository as the content of .gitconfig is not automatically applied to prevent security vulnerabilities: "git config --local include.path ../.gitconfig"
+
+# Define merge strategy "ours"
+[merge "ours"]
+	driver = true


### PR DESCRIPTION
- Define a custom merge strategy with in fact does nothing but return true
- Apply this merge strategy to all translated strings in the repositors to prevent them from being process during merging branches

The change is targeted to `release`  and will be merged upstream afterwards to enable it on both branches.

Test for https://github.com/cgeo/cgeo/issues/9259
