### PR TITLE
set sdk level to 29, adding legacyStorage flag (fix #209)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,13 +26,13 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         applicationId "menion.android.whereyougo"
         minSdkVersion 16
         //noinspection OldTargetApi
-        targetSdkVersion 28
+        targetSdkVersion 29
 
         versionName versionNameFromDate()
         versionCode versionCodeFromDate(0)

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -32,7 +32,8 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme"
-        tools:replace="icon, label">
+        tools:replace="icon, label"
+        android:requestLegacyExternalStorage="true">
         <activity
             android:name="menion.android.whereyougo.gui.activity.MainActivity"
             android:label="WhereYouGo">


### PR DESCRIPTION
To be upgradable after Nov 2 (new targetSDK rules enforced by Play Store):
- set compileSDK and targetSDK to 29
- add flag `requestLegacyExternalStorage` to true
