### PR TITLE
use editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{gradle,java}]
+indent_size = 4
+indent_style = space


### PR DESCRIPTION
Adds a basic configuration (.editorconfig) that can be handled by many editors, see https://editorconfig.org/ for more details.
The AS comes with the bundled plugin EditorConfig so no need to install something.
(see also https://github.com/cgeo/cgeo/pull/9134)