### PR TITLE
configure dependabot for dependency resolution

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
As discussed in https://github.com/cgeo/cgeo/issues/9677 let's activate dependabot here in the WhereYouGo repo first before using it in c:geo...