### PR TITLE
Hotfix: Android 12 Compatibility

### DIFF
--- a/src/main/java/menion/android/whereyougo/geo/location/GpsConnection.java
+++ b/src/main/java/menion/android/whereyougo/geo/location/GpsConnection.java
@@ -44,7 +44,6 @@ public class GpsConnection {
     private final MyLocationListener llGPS;
     private final MyLocationListener llNetwork;
     private final MyGpsListener gpsListener;
-    private final MyGnssListener gnssListener;
     private boolean isFixed;
     private Timer mGpsTimer;
     // temp variable for indicating whether network provider is enabled
@@ -59,7 +58,6 @@ public class GpsConnection {
         llGPS = new MyLocationListener();
         llNetwork = new MyLocationListener();
         gpsListener = new MyGpsListener();
-        gnssListener = new MyGnssListener();
 
         // init basic fixing values
         isFixed = false;
@@ -107,6 +105,7 @@ public class GpsConnection {
         // add new listener GPS
         try {
             if (Build.VERSION.SDK_INT >= 24 ) {
+                MyGnssListener gnssListener = new MyGnssListener();
                 locationManager.registerGnssStatusCallback(gnssListener);
             }
             else {

--- a/src/main/java/menion/android/whereyougo/geo/location/GpsConnection.java
+++ b/src/main/java/menion/android/whereyougo/geo/location/GpsConnection.java
@@ -51,7 +51,6 @@ public class GpsConnection {
     private boolean networkProviderEnabled;
     private boolean gpsProviderEnabled;
     private GpsStatus gpsStatus;
-    private GnssStatus gnssStatus;
 
     public GpsConnection(Context context) {
         Logger.w(TAG, "onCreate()");

--- a/src/main/java/menion/android/whereyougo/geo/location/LocationState.java
+++ b/src/main/java/menion/android/whereyougo/geo/location/LocationState.java
@@ -505,10 +505,8 @@ public class LocationState {
             } else if (Build.VERSION.SDK_INT >= 24) {
                 LocationManager lm;
                 lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
-                if (lm!=null) {
-                    if (lm.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
-                        gpsConn = new GpsConnection(context);
-                    }
+                if (lm!=null && lm.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
+                    gpsConn = new GpsConnection(context);
                 }
             } else {
                 UtilsGUI.showDialogQuestion(PreferenceValues.getCurrentActivity(), R.string.gps_not_enabled_show_system_settings,


### PR DESCRIPTION
## Description
Android API 24 deprecated use of class `LocationManager.GpsStatus`, since GPS is proprietary satellite system. Since Android 12 (API 31) is `GpsStatus` use prohibited and system denies calls for location-related methods when using deprecated `GpsStatus` class.

- Replaced deprecated `GpsStatus` since API 24, implemented `GnssStatus`
- Fixed message asking for permissions even when granted (changed location provider check)

Changed files:
- `geo/location/LocationState.java`
- `geo/location/GpsConnection.java`

## Related issues
- #306

## Additional context
- [GpsStatus class deprecation notice](https://developer.android.com/reference/android/location/GpsStatus)
- [GnssStatus class reference guide](https://developer.android.com/reference/android/location/GnssStatus)