### PR TITLE
Fix #274 - Set target SDK 30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ android {
         applicationId "menion.android.whereyougo"
         minSdkVersion 16
         //noinspection OldTargetApi
-        targetSdkVersion 29
+        targetSdkVersion 30
 
         versionName versionNameFromDate()
         versionCode versionCodeFromDate(0)


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Set target SDK API 30 for further testing in nightlies


## Related issues
<!-- List the related issues fixed or improved by this PR -->
#274

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
Target SDK API 31 did not compile, therefore using API 30 for now.