### PR TITLE
Hotfix/297 Openstreetmaps.org download error

### DIFF
--- a/src/main/java/menion/android/whereyougo/maps/mapsforge/mapgenerator/MapGeneratorFactory.java
+++ b/src/main/java/menion/android/whereyougo/maps/mapsforge/mapgenerator/MapGeneratorFactory.java
@@ -14,6 +14,11 @@
  */
 package menion.android.whereyougo.maps.mapsforge.mapgenerator;
 
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.util.AttributeSet;
 
 import org.mapsforge.android.maps.mapgenerator.MapGenerator;
@@ -50,6 +55,7 @@ public final class MapGeneratorFactory {
      * @return a new MapGenerator instance.
      */
     public static MapGenerator createMapGenerator(MapGeneratorInternal mapGeneratorInternal) {
+        System.setProperty("http.agent", "WhereYouGo");
         switch (mapGeneratorInternal) {
             case BLANK:
                 return new Blank();

--- a/src/main/java/menion/android/whereyougo/maps/mapsforge/mapgenerator/MapGeneratorFactory.java
+++ b/src/main/java/menion/android/whereyougo/maps/mapsforge/mapgenerator/MapGeneratorFactory.java
@@ -14,11 +14,6 @@
  */
 package menion.android.whereyougo.maps.mapsforge.mapgenerator;
 
-import android.content.Context;
-import android.content.ContextWrapper;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
-import android.content.res.Configuration;
 import android.util.AttributeSet;
 
 import org.mapsforge.android.maps.mapgenerator.MapGenerator;


### PR DESCRIPTION
## Description

OpenStreetMap.org tile servers forbids use of generic UserAgent values to identify heavy usage of their infrastructure. Since WhereYouGo uses only naive implementation of Mapsforge TileDownloader, common OkHttp header present to servers when downloading tiles. Setting application-level property of UserAgent to `WhereYouGo` enables the ability to use OSM tiles.

There is also another requirement raised with proper attribution of source by changing menu value from OSM: Mapnik to full-name: OpenStreetMap. This should be done with the translations.

## Related issues
- #297 

## Additional context
[Response from OpenStreetMap developer for cgeo tiles usage](https://github.com/openstreetmap/operations/issues/371#issuecomment-598016057)