### PR TITLE
Hotfix for #329 - Incorrect Language

### DIFF
--- a/src/main/java/menion/android/whereyougo/gui/activity/XmlSettingsActivity.java
+++ b/src/main/java/menion/android/whereyougo/gui/activity/XmlSettingsActivity.java
@@ -35,14 +35,15 @@ public class XmlSettingsActivity
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.layout_settings);
-        setTitle(R.string.settings);
-        ((TextView) findViewById(R.id.title_text)).setText(R.string.settings);
-
         // Set language
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         String lang = sharedPreferences.getString(getString(R.string.pref_KEY_S_LANGUAGE), "");
         setLocale(this, lang);
+
+        setContentView(R.layout.layout_settings);
+        setTitle(R.string.settings);
+        ((TextView) findViewById(R.id.title_text)).setText(R.string.settings);
+
 
         /* workaround: I don't really know why I cannot call CustomActivity.customOnCreate(this); - OMG! */
         switch (Preferences.APPEARANCE_FONT_SIZE) {

--- a/src/main/java/menion/android/whereyougo/gui/extension/activity/CustomActivity.java
+++ b/src/main/java/menion/android/whereyougo/gui/extension/activity/CustomActivity.java
@@ -253,10 +253,11 @@ public class CustomActivity extends FragmentActivity {
     }
 
     public static void setLocale(Activity activity, String languageCode) {
+        String lang = languageCode;
         if (languageCode.equals("default")) {
-            languageCode = Locale.getDefault().getLanguage();
+            lang = Locale.getDefault().getLanguage();
         }
-        Locale locale = new Locale(languageCode);
+        Locale locale = new Locale(lang);
         Locale.setDefault(locale);
         Resources resources = activity.getResources();
         Configuration config = resources.getConfiguration();

--- a/src/main/java/menion/android/whereyougo/gui/extension/activity/CustomActivity.java
+++ b/src/main/java/menion/android/whereyougo/gui/extension/activity/CustomActivity.java
@@ -1,17 +1,17 @@
 /*
  * This file is part of WhereYouGo.
- * 
+ *
  * WhereYouGo is free software: you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * WhereYouGo is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with WhereYouGo. If not,
  * see <http://www.gnu.org/licenses/>.
- * 
+ *
  * Copyright (C) 2012 Menion <whereyougo@asamm.cz>
  */
 
@@ -54,6 +54,7 @@ public class CustomActivity extends FragmentActivity {
         // Set language
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         String lang = sharedPreferences.getString(getString(R.string.pref_KEY_S_LANGUAGE), "");
+        Logger.v(TAG, "customOnCreate(), lang: " + lang);
         setLocale(this, lang);
 
         // set main activity parameters
@@ -252,11 +253,16 @@ public class CustomActivity extends FragmentActivity {
     }
 
     public static void setLocale(Activity activity, String languageCode) {
+        if (languageCode.equals("default")) {
+            languageCode = Locale.getDefault().getLanguage();
+        }
         Locale locale = new Locale(languageCode);
         Locale.setDefault(locale);
         Resources resources = activity.getResources();
         Configuration config = resources.getConfiguration();
         config.setLocale(locale);
         resources.updateConfiguration(config, resources.getDisplayMetrics());
+        config.locale = locale;
+        activity.getApplicationContext().createConfigurationContext(config);
     }
 }


### PR DESCRIPTION
## Description

Fixed few language issues:
- incorrect handling of system default language (usually English is used, when default option selected)
- incorrect language loading order on main settings screen, view falling back to english


## Related issues
- #329 

## Additional context
Since app-level method `CustomActivity.setLocale` was changed, I would recommend to test all activities (CartridgeDetails, Guiding, Main, Satellite). I have opened all of them on API 32 and also API 21 emulator, application worked as expected. 

Also remember to force-restart application after changing language in settings. Users should be notified of reqired restart for applying language changes.