### PR TITLE
Regional languages support

### DIFF
--- a/src/main/java/menion/android/whereyougo/gui/activity/XmlSettingsActivity.java
+++ b/src/main/java/menion/android/whereyougo/gui/activity/XmlSettingsActivity.java
@@ -16,12 +16,11 @@ import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceManager;
 
 import menion.android.whereyougo.R;
+import menion.android.whereyougo.gui.extension.activity.CustomActivity;
 import menion.android.whereyougo.preferences.PreferenceValues;
 import menion.android.whereyougo.preferences.Preferences;
 import menion.android.whereyougo.utils.Logger;
 import menion.android.whereyougo.utils.Utils;
-
-import static menion.android.whereyougo.gui.extension.activity.CustomActivity.setLocale;
 
 
 public class XmlSettingsActivity
@@ -38,12 +37,11 @@ public class XmlSettingsActivity
         // Set language
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         String lang = sharedPreferences.getString(getString(R.string.pref_KEY_S_LANGUAGE), "");
-        setLocale(this, lang);
+        CustomActivity.setLocale(this, lang);
 
         setContentView(R.layout.layout_settings);
         setTitle(R.string.settings);
         ((TextView) findViewById(R.id.title_text)).setText(R.string.settings);
-
 
         /* workaround: I don't really know why I cannot call CustomActivity.customOnCreate(this); - OMG! */
         switch (Preferences.APPEARANCE_FONT_SIZE) {

--- a/src/main/java/menion/android/whereyougo/gui/activity/XmlSettingsActivity.java
+++ b/src/main/java/menion/android/whereyougo/gui/activity/XmlSettingsActivity.java
@@ -35,14 +35,15 @@ public class XmlSettingsActivity
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.layout_settings);
-        setTitle(R.string.settings);
-        ((TextView) findViewById(R.id.title_text)).setText(R.string.settings);
-
         // Set language
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         String lang = sharedPreferences.getString(getString(R.string.pref_KEY_S_LANGUAGE), "");
         setLocale(this, lang);
+
+        setContentView(R.layout.layout_settings);
+        setTitle(R.string.settings);
+        ((TextView) findViewById(R.id.title_text)).setText(R.string.settings);
+
 
         /* workaround: I don't really know why I cannot call CustomActivity.customOnCreate(this); - OMG! */
         switch (Preferences.APPEARANCE_FONT_SIZE) {

--- a/src/main/java/menion/android/whereyougo/gui/extension/activity/CustomActivity.java
+++ b/src/main/java/menion/android/whereyougo/gui/extension/activity/CustomActivity.java
@@ -253,14 +253,34 @@ public class CustomActivity extends FragmentActivity {
     }
 
     public static void setLocale(Activity activity, String languageCode) {
-        String lang = languageCode;
-        if (languageCode.equals("default")) {
-            lang = Locale.getDefault().getLanguage();
-        }
-        Locale locale = new Locale(lang);
-        Locale.setDefault(locale);
+        Locale locale;
+        String lang;
         Resources resources = activity.getResources();
         Configuration config = resources.getConfiguration();
+
+        // we need to get language and region first even for default to correctly initialize Locale
+        if (languageCode.equals("default")) {
+            lang = Locale.getDefault().toString();
+        } else {
+            lang = new Locale(languageCode).toString();
+        }
+
+        // need to parse language codes with dash and hyphen
+        String[] loc = lang.split("[-_]");
+        if (loc.length == 1) {
+            if (loc[0].equals("pt")) {
+                // nasty hotfix for Portuguese language selected without regional code
+                locale = new Locale(loc[0], loc[0]);
+            } else {
+                locale = new Locale(lang);
+            }
+        } else if (loc.length == 2) {
+            locale = new Locale(loc[0], loc[1]);
+        } else {
+            locale = config.locale;
+        }
+
+        Locale.setDefault(locale);
         config.setLocale(locale);
         resources.updateConfiguration(config, resources.getDisplayMetrics());
         config.locale = locale;

--- a/src/main/java/menion/android/whereyougo/gui/extension/activity/CustomActivity.java
+++ b/src/main/java/menion/android/whereyougo/gui/extension/activity/CustomActivity.java
@@ -253,10 +253,11 @@ public class CustomActivity extends FragmentActivity {
     }
 
     public static void setLocale(Activity activity, String languageCode) {
+        String lang = languageCode;
         if (languageCode.equals("default")) {
-            languageCode = Locale.getDefault().getLanguage();
+            lang = Locale.getDefault().getLanguage();
         }
-        Locale locale = new Locale(languageCode);
+        Locale locale = new Locale(lang);
         Locale.setDefault(locale);
         Resources resources = activity.getResources();
         Configuration config = resources.getConfiguration();

--- a/src/main/java/menion/android/whereyougo/gui/extension/activity/CustomActivity.java
+++ b/src/main/java/menion/android/whereyougo/gui/extension/activity/CustomActivity.java
@@ -1,17 +1,17 @@
 /*
  * This file is part of WhereYouGo.
- * 
+ *
  * WhereYouGo is free software: you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * WhereYouGo is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with WhereYouGo. If not,
  * see <http://www.gnu.org/licenses/>.
- * 
+ *
  * Copyright (C) 2012 Menion <whereyougo@asamm.cz>
  */
 
@@ -54,6 +54,7 @@ public class CustomActivity extends FragmentActivity {
         // Set language
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         String lang = sharedPreferences.getString(getString(R.string.pref_KEY_S_LANGUAGE), "");
+        Logger.v(TAG, "customOnCreate(), lang: " + lang);
         setLocale(this, lang);
 
         // set main activity parameters
@@ -252,11 +253,16 @@ public class CustomActivity extends FragmentActivity {
     }
 
     public static void setLocale(Activity activity, String languageCode) {
+        if (languageCode.equals("default")) {
+            languageCode = Locale.getDefault().getLanguage();
+        }
         Locale locale = new Locale(languageCode);
         Locale.setDefault(locale);
         Resources resources = activity.getResources();
         Configuration config = resources.getConfiguration();
         config.setLocale(locale);
         resources.updateConfiguration(config, resources.getDisplayMetrics());
+        config.locale = locale;
+        activity.getApplicationContext().createConfigurationContext(config);
     }
 }


### PR DESCRIPTION
## Description
Reworked `CustomActivity.setLocale()` to internally handle regional and non-regional language codes on various system versions.

## Related issues
- #329 

## Additional context
This code contains hardcoded check for Portuguese language (as the only regional-coded language in this project right now), since various Android devices may report this language as non-regional, causing falling back to English even when proper language asset is present.