### PR TITLE
hotfix for (#329) support for regional language codes

### DIFF
--- a/src/main/java/menion/android/whereyougo/gui/activity/XmlSettingsActivity.java
+++ b/src/main/java/menion/android/whereyougo/gui/activity/XmlSettingsActivity.java
@@ -16,12 +16,11 @@ import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceManager;
 
 import menion.android.whereyougo.R;
+import menion.android.whereyougo.gui.extension.activity.CustomActivity;
 import menion.android.whereyougo.preferences.PreferenceValues;
 import menion.android.whereyougo.preferences.Preferences;
 import menion.android.whereyougo.utils.Logger;
 import menion.android.whereyougo.utils.Utils;
-
-import static menion.android.whereyougo.gui.extension.activity.CustomActivity.setLocale;
 
 
 public class XmlSettingsActivity
@@ -38,7 +37,7 @@ public class XmlSettingsActivity
         // Set language
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         String lang = sharedPreferences.getString(getString(R.string.pref_KEY_S_LANGUAGE), "");
-        setLocale(this, lang);
+        CustomActivity.setLocale(this, lang);
 
         setContentView(R.layout.layout_settings);
         setTitle(R.string.settings);

--- a/src/main/java/menion/android/whereyougo/gui/extension/activity/CustomActivity.java
+++ b/src/main/java/menion/android/whereyougo/gui/extension/activity/CustomActivity.java
@@ -253,14 +253,34 @@ public class CustomActivity extends FragmentActivity {
     }
 
     public static void setLocale(Activity activity, String languageCode) {
-        String lang = languageCode;
-        if (languageCode.equals("default")) {
-            lang = Locale.getDefault().getLanguage();
-        }
-        Locale locale = new Locale(lang);
-        Locale.setDefault(locale);
+        Locale locale;
+        String lang;
         Resources resources = activity.getResources();
         Configuration config = resources.getConfiguration();
+
+        // we need to get language and region first even for default to correctly initialize Locale
+        if (languageCode.equals("default")) {
+            lang = Locale.getDefault().toString();
+        } else {
+            lang = new Locale(languageCode).toString();
+        }
+
+        // need to parse language codes with dash and hyphen
+        String[] loc = lang.split("[-_]");
+        if (loc.length == 1) {
+            if (loc[0].equals("pt")) {
+                // nasty hotfix for Portuguese language selected without regional code
+                locale = new Locale(loc[0], loc[0]);
+            } else {
+                locale = new Locale(lang);
+            }
+        } else if (loc.length == 2) {
+            locale = new Locale(loc[0], loc[1]);
+        } else {
+            locale = config.locale;
+        }
+
+        Locale.setDefault(locale);
         config.setLocale(locale);
         resources.updateConfiguration(config, resources.getDisplayMetrics());
         config.locale = locale;


### PR DESCRIPTION
Fixes #329 

## Description
Reworked `CustomActivity.setLocale()` to internally handle regional and non-regional language codes on various system versions.

## Related issues
- #329 

## Additional context
This code contains hardcoded check for Portuguese language (as the only regional-coded language in this project right now), since various Android devices may report this language as non-regional, causing falling back to English even when proper language asset is present.