### PR TITLE
hotfix for (#337) crash on settings change

### DIFF
--- a/src/main/java/menion/android/whereyougo/gui/fragments/settings/SettingsAppearanceFragment.java
+++ b/src/main/java/menion/android/whereyougo/gui/fragments/settings/SettingsAppearanceFragment.java
@@ -1,6 +1,7 @@
 package menion.android.whereyougo.gui.fragments.settings;
 
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Bundle;
 
 import androidx.preference.CheckBoxPreference;
@@ -24,6 +25,9 @@ public class SettingsAppearanceFragment extends PreferenceFragmentCompat {
         CheckBoxPreference imageStretch = findPreference(Preferences.getKey(R.string.pref_KEY_B_IMAGE_STRETCH));
 
         if (statusbarIcon != null) {
+            if (Preferences.GLOBAL_RUN_SCREEN_OFF && Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+                statusbarIcon.setEnabled(false);
+            }
             statusbarIcon.setOnPreferenceChangeListener((preference, o) -> {
                 boolean newValue = (boolean) o;
                 Preferences.APPEARANCE_STATUSBAR = Utils.parseBoolean(newValue);

--- a/src/main/java/menion/android/whereyougo/gui/fragments/settings/SettingsGlobalFragment.java
+++ b/src/main/java/menion/android/whereyougo/gui/fragments/settings/SettingsGlobalFragment.java
@@ -56,10 +56,6 @@ public class SettingsGlobalFragment extends PreferenceFragmentCompat {
             runScreenOff.setOnPreferenceChangeListener((preference, o) -> {
                 boolean newValue = (boolean) o;
                 Preferences.GLOBAL_RUN_SCREEN_OFF = Utils.parseBoolean(newValue);
-                CheckBoxPreference status_bar = findPreference(Preferences.getKey(R.string.pref_KEY_B_STATUSBAR));
-                if (Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P && newValue) {
-                    status_bar.setEnabled(false);
-                }
                 PreferenceValues.enableWakeLock();
                 return true;
             });


### PR DESCRIPTION
Fixes #337 

## Description

- refactored settings pointing to moved preference value to another screen, caused NullPointerException
- fixed with moving enable/disable code for status icon to appearance settings fragment

Affected files:
- `SettingsGlobalFragment.java`
- `SettingsAppearanceFragment.java`

## Related issues
- #337 