### PR TITLE
hotfix for (#334) require restart on language change

### DIFF
--- a/src/main/java/menion/android/whereyougo/gui/activity/MainActivity.java
+++ b/src/main/java/menion/android/whereyougo/gui/activity/MainActivity.java
@@ -21,8 +21,10 @@ import android.Manifest;
 import android.app.ActivityManager;
 import android.app.AlertDialog;
 import android.app.NotificationManager;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Debug;
@@ -355,15 +357,16 @@ public class MainActivity extends CustomActivity {
                     finish();
                 } else if (finishType == FINISH_RESTART || finishType == FINISH_RESTART_FORCE
                         || finishType == FINISH_RESTART_FACTORY_RESET) {
-                    // Setup one-short alarm to restart my application in 3 seconds - TODO need use
-                    // another context
-                    // AlarmManager alarmMgr = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
-                    // Intent intent = new Intent(APP_INTENT_MAIN);
-                    // PendingIntent pi = PendingIntent.getBroadcast(CustomMain.this, 0, intent,
-                    // PendingIntent.FLAG_ONE_SHOT);
-                    // alarmMgr.set(AlarmManager.ELAPSED_REALTIME, System.currentTimeMillis() + 3000, pi);
-                    finish = true;
-                    finish();
+                    Context context = getApplicationContext();
+                    Intent notifyIntent = new Intent(context, NotificationService.class);
+                    notifyIntent.putExtra(NotificationService.TITEL, A.getAppName());
+                    notifyIntent.setAction(NotificationService.STOP_NOTIFICATION_SERVICE);
+                    context.startService(notifyIntent);
+                    PackageManager packageManager = context.getPackageManager();
+                    Intent runAppIntent = packageManager.getLaunchIntentForPackage(context.getPackageName());
+                    ComponentName componentName = runAppIntent.getComponent();
+                    Intent restartIntent = Intent.makeRestartActivityTask(componentName);
+                    context.startActivity(restartIntent);
                 } else if (finishType == FINISH_REINSTALL) {
                     // Intent intent = new Intent();
                     // intent.setAction(android.content.Intent.ACTION_VIEW);

--- a/src/main/java/menion/android/whereyougo/gui/fragments/settings/SettingsLocalizationFragment.java
+++ b/src/main/java/menion/android/whereyougo/gui/fragments/settings/SettingsLocalizationFragment.java
@@ -8,10 +8,19 @@ import androidx.preference.ListPreference;
 import androidx.preference.PreferenceFragmentCompat;
 
 import menion.android.whereyougo.R;
+import menion.android.whereyougo.gui.activity.MainActivity;
 import menion.android.whereyougo.preferences.Preferences;
+import menion.android.whereyougo.utils.A;
+import menion.android.whereyougo.utils.Logger;
 import menion.android.whereyougo.utils.Utils;
 
 public class SettingsLocalizationFragment extends PreferenceFragmentCompat {
+
+    private static String TAG = "SettingsLocalizationFragment";
+
+    private boolean restartRequired = false;
+    private String currentLanguage;
+
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         setPreferencesFromResource(R.xml.whereyougo_preferences_localization, rootKey);
@@ -27,6 +36,7 @@ public class SettingsLocalizationFragment extends PreferenceFragmentCompat {
     private void prepareLanguage() {
         ListPreference language = findPreference(Preferences.getKey(R.string.pref_KEY_S_LANGUAGE));
         if (language != null) {
+            currentLanguage = language.getValue();
             language.setSummaryProvider(preference -> {
                 SharedPreferences preferences = preference.getSharedPreferences();
                 String currentValue = preferences.getString(preference.getKey(), "");
@@ -34,6 +44,11 @@ public class SettingsLocalizationFragment extends PreferenceFragmentCompat {
                     return getString(R.string.pref_language_desc);
                 }
                 return getString(R.string.pref_language_summary, currentValue);
+            });
+            language.setOnPreferenceChangeListener((preference, o) -> {
+                String newLanguage = (String) o;
+                restartRequired = !(newLanguage.equals(currentLanguage));
+                return true;
             });
         }
     }
@@ -172,6 +187,18 @@ public class SettingsLocalizationFragment extends PreferenceFragmentCompat {
                         return getString(R.string.pref_units_length_desc);
                 }
             });
+        }
+    }
+
+    @Override
+    public void onDestroy() {
+        try {
+            super.onDestroy();
+            if (restartRequired) {
+                A.getMain().showDialogFinish(MainActivity.FINISH_RESTART);
+            }
+        } catch (Exception e) {
+            Logger.e(TAG, "onDestroy()", e);
         }
     }
 }


### PR DESCRIPTION
fixes #334 

## Description
- when leaving settings after language change, user is asked to restart application using existing finish dialog
- working restart intent, `MainApplication.class` is recreated after restart is confirmed in dialog, functionality was left as TODO item in the whole history of project on GitHub


## Related issues
- #334 

