### PR TITLE
fix #357 Locus integration not working

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ dependencies {
 
     // Locus Maps integration
     //noinspection GradleDependency
-    implementation 'com.asamm:locus-api-android:0.2.7'
+    implementation 'com.asamm:locus-api-android:0.9.45'
 
     // openwig@cgeo
     implementation 'com.github.cgeo:openwig:1.0.0'

--- a/src/main/java/menion/android/whereyougo/geo/location/Location.java
+++ b/src/main/java/menion/android/whereyougo/geo/location/Location.java
@@ -7,10 +7,10 @@ public class Location extends locus.api.objects.extra.Location {
     }
 
     public Location(android.location.Location loc) {
-        this(loc.getProvider(), loc.getLatitude(), loc.getLongitude());
+        this(loc.getLatitude(), loc.getLongitude());
         setTime(loc.getTime());
         if (loc.hasAccuracy()) {
-            setAccuracy(loc.getAccuracy());
+            setAccuracyHor(loc.getAccuracy());
         }
         if (loc.hasAltitude()) {
             setAltitude(loc.getAltitude());
@@ -27,12 +27,8 @@ public class Location extends locus.api.objects.extra.Location {
         super(loc);
     }
 
-    public Location(String provider) {
-        super(provider);
-    }
-
-    public Location(String provider, double lat, double lon) {
-        super(provider, lat, lon);
+    public Location(double lat, double lon) {
+        super(lat, lon);
     }
 
     @Override

--- a/src/main/java/menion/android/whereyougo/geo/location/LocationState.java
+++ b/src/main/java/menion/android/whereyougo/geo/location/LocationState.java
@@ -1,17 +1,17 @@
 /*
  * This file is part of WhereYouGo.
- * 
+ *
  * WhereYouGo is free software: you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * WhereYouGo is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with WhereYouGo. If not,
  * see <http://www.gnu.org/licenses/>.
- * 
+ *
  * Copyright (C) 2012 Menion <whereyougo@asamm.cz>
  */
 
@@ -147,7 +147,7 @@ public class LocationState {
 
     public static Location getLocation() {
         if (location == null)
-            return new Location(TAG);
+            return new Location();
         return new Location(location);
     }
 
@@ -331,7 +331,7 @@ public class LocationState {
                 // if first location from Network, and new from GPS but with worst precision, do not set
                 if (LocationState.location.getProvider().equals(LocationManager.NETWORK_PROVIDER)
                         && location.getProvider().equals(LocationManager.GPS_PROVIDER)
-                        && (LocationState.location.getAccuracy() * 3) < location.getAccuracy()) {
+                        && (LocationState.location.getAccuracyHor() * 3) < location.getAccuracyHor()) {
                     return;
                 }
 

--- a/src/main/java/menion/android/whereyougo/gui/activity/CartridgeDetailsActivity.java
+++ b/src/main/java/menion/android/whereyougo/gui/activity/CartridgeDetailsActivity.java
@@ -74,7 +74,7 @@ public class CartridgeDetailsActivity extends CustomActivity {
 
         TextView tvDistance = (TextView) findViewById(R.id.layoutDetailsTextViewDistance);
 
-        Location loc = new Location(TAG);
+        Location loc = new Location();
         loc.setLatitude(MainActivity.cartridgeFile.latitude);
         loc.setLongitude(MainActivity.cartridgeFile.longitude);
 
@@ -92,7 +92,7 @@ public class CartridgeDetailsActivity extends CustomActivity {
             MainActivity.startSelectedCartridge(false);
             return true;
         }, null, null, getString(R.string.navigate), (dialog, v, btn) -> {
-            Location loc1 = new Location(TAG);
+            Location loc1 = new Location();
             loc1.setLatitude(MainActivity.cartridgeFile.latitude);
             loc1.setLongitude(MainActivity.cartridgeFile.longitude);
             Guide guide = new Guide(MainActivity.cartridgeFile.name, loc1);

--- a/src/main/java/menion/android/whereyougo/gui/activity/GuidingActivity.java
+++ b/src/main/java/menion/android/whereyougo/gui/activity/GuidingActivity.java
@@ -1,17 +1,17 @@
 /*
  * This file is part of WhereYouGo.
- * 
+ *
  * WhereYouGo is free software: you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * WhereYouGo is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with WhereYouGo. If not,
  * see <http://www.gnu.org/licenses/>.
- * 
+ *
  * Copyright (C) 2012 Menion <whereyougo@asamm.cz>
  */
 
@@ -132,7 +132,7 @@ public class GuidingActivity extends CustomActivity implements IGuideEventListen
         viewLat.setText(UtilsFormat.formatLatitude(loc.getLatitude()));
         viewLon.setText(UtilsFormat.formatLongitude(loc.getLongitude()));
         viewAlt.setText(UtilsFormat.formatAltitude(loc.getAltitude(), true));
-        viewAcc.setText(UtilsFormat.formatDistance((double) loc.getAccuracy(), false));
+        viewAcc.setText(UtilsFormat.formatDistance((double) loc.getAccuracyHor(), false));
         viewSpeed.setText(UtilsFormat.formatSpeed(loc.getSpeed(), false));
 
         repaint();

--- a/src/main/java/menion/android/whereyougo/gui/activity/MainActivity.java
+++ b/src/main/java/menion/android/whereyougo/gui/activity/MainActivity.java
@@ -1,17 +1,17 @@
 /*
  * This file is part of WhereYouGo.
- * 
+ *
  * WhereYouGo is free software: you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * WhereYouGo is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with WhereYouGo. If not,
  * see <http://www.gnu.org/licenses/>.
- * 
+ *
  * Copyright (C) 2012 Menion <whereyougo@asamm.cz>
  */
 
@@ -49,7 +49,8 @@ import java.util.Vector;
 import cz.matejcik.openwig.Engine;
 import cz.matejcik.openwig.formats.CartridgeFile;
 import locus.api.objects.extra.Location;
-import locus.api.objects.extra.Waypoint;
+
+//import locus.api.objects.extra.Waypoint;
 
 import menion.android.whereyougo.MainApplication;
 import menion.android.whereyougo.R;
@@ -179,9 +180,6 @@ public class MainActivity extends CustomActivity {
         File[] files = FileSystem.getFiles(FileSystem.ROOT, "gwc");
         cartridgeFiles = new Vector<>();
 
-        // add cartridges to map
-        ArrayList<Waypoint> wpts = new ArrayList<>();
-
         File actualFile = null;
         if (files != null) {
             for (File file : files) {
@@ -190,25 +188,13 @@ public class MainActivity extends CustomActivity {
                     CartridgeFile cart = CartridgeFile.read(new WSeekableFile(file), new WSaveFile(file));
                     if (cart != null) {
                         cart.filename = file.getAbsolutePath();
-
-                        Location loc = new Location(TAG);
-                        loc.setLatitude(cart.latitude);
-                        loc.setLongitude(cart.longitude);
-                        Waypoint waypoint = new Waypoint(cart.name, loc);
-
                         cartridgeFiles.add(cart);
-                        wpts.add(waypoint);
                     }
                 } catch (Exception e) {
                     Logger.w(TAG, "refreshCartridge(), file:" + actualFile + ", e:" + e.toString());
                     ManagerNotify.toastShortMessage(Locale.getString(R.string.invalid_cartridge, actualFile.getName()));
-                    // file.delete();
                 }
             }
-        }
-
-        if (wpts.size() > 0) {
-            // TODO add items on map
         }
     }
 

--- a/src/main/java/menion/android/whereyougo/gui/activity/SatelliteActivity.java
+++ b/src/main/java/menion/android/whereyougo/gui/activity/SatelliteActivity.java
@@ -1,17 +1,17 @@
 /*
  * This file is part of WhereYouGo.
- * 
+ *
  * WhereYouGo is free software: you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * WhereYouGo is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with WhereYouGo. If not,
  * see <http://www.gnu.org/licenses/>.
- * 
+ *
  * Copyright (C) 2012 Menion <whereyougo@asamm.cz>
  */
 
@@ -162,7 +162,7 @@ public class SatelliteActivity extends CustomActivity implements ILocationEventL
                 ((TextView) findViewById(R.id.text_view_altitude)).setText(UtilsFormat.formatAltitude(
                         location.getAltitude(), true));
                 ((TextView) findViewById(R.id.text_view_accuracy)).setText(UtilsFormat.formatDistance(
-                        location.getAccuracy(), false));
+                        location.getAccuracyHor(), false));
                 ((TextView) findViewById(R.id.text_view_speed)).setText(UtilsFormat.formatSpeed(
                         location.getSpeed(), false));
                 ((TextView) findViewById(R.id.text_view_declination)).setText(UtilsFormat

--- a/src/main/java/menion/android/whereyougo/gui/dialog/ChooseCartridgeDialog.java
+++ b/src/main/java/menion/android/whereyougo/gui/dialog/ChooseCartridgeDialog.java
@@ -50,8 +50,8 @@ public class ChooseCartridgeDialog extends CustomDialogFragment {
         try {
             // sort cartridges
             final Location actLoc = LocationState.getLocation();
-            final Location loc1 = new Location(TAG);
-            final Location loc2 = new Location(TAG);
+            final Location loc1 = new Location();
+            final Location loc2 = new Location();
             Collections.sort(cartridgeFiles, (object1, object2) -> {
                 loc1.setLatitude(object1.latitude);
                 loc1.setLongitude(object1.longitude);

--- a/src/main/java/menion/android/whereyougo/gui/extension/DataInfo.java
+++ b/src/main/java/menion/android/whereyougo/gui/extension/DataInfo.java
@@ -1,17 +1,17 @@
 /*
  * This file is part of WhereYouGo.
- * 
+ *
  * WhereYouGo is free software: you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * WhereYouGo is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with WhereYouGo. If not,
  * see <http://www.gnu.org/licenses/>.
- * 
+ *
  * Copyright (C) 2012 Menion <whereyougo@asamm.cz>
  */
 
@@ -175,7 +175,7 @@ public class DataInfo implements Comparable<DataInfo> {
     }
 
     public Location getLocation() {
-        Location loc = new Location(TAG);
+        Location loc = new Location();
         loc.setLatitude(value01);
         loc.setLongitude(value02);
         return loc;

--- a/src/main/java/menion/android/whereyougo/guide/ZoneGuide.java
+++ b/src/main/java/menion/android/whereyougo/guide/ZoneGuide.java
@@ -12,8 +12,7 @@ public class ZoneGuide extends Guide {
     private boolean mAlreadyEntered = false;
 
     public ZoneGuide(Zone zone) {
-        super(zone.name, new Location("Guidance: " + zone.name, zone.bbCenter.latitude,
-                zone.bbCenter.longitude));
+        super(zone.name, new Location(zone.bbCenter.latitude, zone.bbCenter.longitude));
         mZone = zone;
         mAlreadyEntered = false;
     }
@@ -21,14 +20,14 @@ public class ZoneGuide extends Guide {
   /*
    * public void actualizeState(Location location) { super.actualizeState(location); if
    * (mAlreadyEntered == false && mZone.contain == Zone.INSIDE) { mAlreadyEntered = true;
-   * 
+   *
    * // issue #54 - acoustical switch (Preferences.GUIDING_WAYPOINT_SOUND) { case
    * PreferenceValues.VALUE_GUIDING_WAYPOINT_SOUND_INCREASE_CLOSER: case
    * PreferenceValues.VALUE_GUIDING_WAYPOINT_SOUND_BEEP_ON_DISTANCE: playSingleBeep(); break; case
    * PreferenceValues.VALUE_GUIDING_WAYPOINT_SOUND_CUSTOM_SOUND: playCustomSound(); break; }
-   * 
+   *
    * // issue #54 - visual //ManagerNotify.toastShortMessage(R.string.guidance_zone_entered);
-   * 
+   *
    * // issue #54 - vibration Vibrator v = (Vibrator)
    * A.getMain().getSystemService(Context.VIBRATOR_SERVICE); v.vibrate(50); } }
    */

--- a/src/main/java/menion/android/whereyougo/maps/utils/MapHelper.java
+++ b/src/main/java/menion/android/whereyougo/maps/utils/MapHelper.java
@@ -18,7 +18,6 @@ package menion.android.whereyougo.maps.utils;
 import android.app.Activity;
 import android.content.Intent;
 
-import cz.matejcik.openwig.Action;
 import cz.matejcik.openwig.EventTable;
 import locus.api.android.ActionDisplayVarious.ExtraAction;
 import locus.api.android.ActionDisplayPoints;

--- a/src/main/java/menion/android/whereyougo/maps/utils/MapHelper.java
+++ b/src/main/java/menion/android/whereyougo/maps/utils/MapHelper.java
@@ -1,14 +1,14 @@
 /*
  * Copyright 2013, 2014 biylda <biylda@gmail.com>
- * 
+ *
  * This program is free software: you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program. If not,
  * see <http://www.gnu.org/licenses/>.
  */
@@ -18,13 +18,16 @@ package menion.android.whereyougo.maps.utils;
 import android.app.Activity;
 import android.content.Intent;
 
+import cz.matejcik.openwig.Action;
 import cz.matejcik.openwig.EventTable;
-import locus.api.android.ActionDisplay.ExtraAction;
+import locus.api.android.ActionDisplayVarious.ExtraAction;
 import locus.api.android.ActionDisplayPoints;
 import locus.api.android.ActionDisplayTracks;
-import locus.api.android.ActionTools;
+import locus.api.android.ActionBasics;
 import locus.api.android.utils.LocusUtils;
 import locus.api.android.utils.exceptions.RequiredVersionMissingException;
+import locus.api.objects.extra.Location;
+import locus.api.objects.geoData.Point;
 import menion.android.whereyougo.gui.activity.MainActivity;
 import menion.android.whereyougo.gui.utils.UtilsWherigo;
 import menion.android.whereyougo.maps.mapsforge.MapsforgeActivity;
@@ -73,16 +76,16 @@ public class MapHelper {
     public static void locusMap(Activity activity, EventTable et) {
         LocusMapDataProvider mdp = LocusMapDataProvider.getInstance();
         try {
-            ActionDisplayPoints.sendPack(activity, mdp.getPoints(), ExtraAction.NONE);
-            ActionDisplayTracks.sendTracks(activity, mdp.getTracks(), ExtraAction.CENTER);
+            ActionDisplayPoints.INSTANCE.sendPack(activity, mdp.getPoints(), ExtraAction.NONE);
+            ActionDisplayTracks.INSTANCE.sendTracks(activity, mdp.getTracks(), ExtraAction.CENTER);
             if (et != null && et.isLocated()) {
-                locus.api.objects.extra.Location loc = UtilsWherigo.extractLocation(et);
-                locus.api.objects.extra.Waypoint wpt = new locus.api.objects.extra.Waypoint(et.name, loc);
-                ActionTools.actionStartGuiding(activity, wpt);
+                Location loc = UtilsWherigo.extractLocation(et);
+                Point wpt = new Point(et.name, loc);
+                ActionBasics.INSTANCE.actionStartGuiding(activity, wpt);
             }
         } catch (RequiredVersionMissingException e) {
             Logger.e(activity.toString(), "MapHelper.showMap() - missing locus version", e);
-            LocusUtils.callInstallLocus(activity);
+            LocusUtils.INSTANCE.callInstallLocus(activity);
         } catch (Exception e) {
             Logger.e(activity.toString(), "MapHelper.showMap() - unknown locus problem", e);
         }

--- a/src/main/java/menion/android/whereyougo/openwig/WLocationService.java
+++ b/src/main/java/menion/android/whereyougo/openwig/WLocationService.java
@@ -1,17 +1,17 @@
 /*
  * This file is part of WhereYouGo.
- * 
+ *
  * WhereYouGo is free software: you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * WhereYouGo is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with WhereYouGo. If not,
  * see <http://www.gnu.org/licenses/>.
- * 
+ *
  * Copyright (C) 2012 Menion <whereyougo@asamm.cz>
  */
 
@@ -50,7 +50,7 @@ public class WLocationService implements LocationService {
     }
 
     public double getPrecision() {
-        return LocationState.getLocation().getAccuracy();
+        return LocationState.getLocation().getAccuracyHor();
     }
 
     public int getState() {

--- a/src/main/java/menion/android/whereyougo/preferences/PreferenceValues.java
+++ b/src/main/java/menion/android/whereyougo/preferences/PreferenceValues.java
@@ -1,17 +1,17 @@
 /*
  * This file is part of WhereYouGo.
- * 
+ *
  * WhereYouGo is free software: you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * WhereYouGo is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with WhereYouGo. If not,
  * see <http://www.gnu.org/licenses/>.
- * 
+ *
  * Copyright (C) 2012 Menion <whereyougo@asamm.cz>
  */
 
@@ -203,7 +203,7 @@ public class PreferenceValues {
     }
 
     public static Location getLastKnownLocation() {
-        Location lastKnownLocation = new Location(TAG);
+        Location lastKnownLocation = new Location();
         lastKnownLocation.setLatitude(Preferences.getDecimalPreference(R.string.pref_KEY_F_LAST_KNOWN_LOCATION_LATITUDE));
         lastKnownLocation.setLongitude(Preferences.getDecimalPreference(R.string.pref_KEY_F_LAST_KNOWN_LOCATION_LONGITUDE));
         lastKnownLocation.setAltitude(Preferences.getDecimalPreference(R.string.pref_KEY_F_LAST_KNOWN_LOCATION_ALTITUDE));

--- a/src/main/java/menion/android/whereyougo/utils/UtilsFormat.java
+++ b/src/main/java/menion/android/whereyougo/utils/UtilsFormat.java
@@ -1,17 +1,17 @@
 /*
  * This file is part of WhereYouGo.
- * 
+ *
  * WhereYouGo is free software: you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * WhereYouGo is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with WhereYouGo. If not,
  * see <http://www.gnu.org/licenses/>.
- * 
+ *
  * Copyright (C) 2012 Menion <whereyougo@asamm.cz>
  */
 
@@ -41,27 +41,27 @@ public class UtilsFormat {
     private static final SimpleDateFormat datetimeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
     public static String formatAltitude(double altitude, boolean addUnits) {
-        return locus.api.android.utils.UtilsFormat.formatAltitude(Preferences.FORMAT_ALTITUDE, altitude, addUnits);
+        return locus.api.android.utils.UtilsFormat.INSTANCE.formatAltitude(Preferences.FORMAT_ALTITUDE, altitude, addUnits);
     }
 
     public static String formatAngle(double angle) {
-        return locus.api.android.utils.UtilsFormat.formatAngle(Preferences.FORMAT_ANGLE, (float) ((angle % 360) + 360) % 360, false, 0);
+        return locus.api.android.utils.UtilsFormat.INSTANCE.formatAngle(Preferences.FORMAT_ANGLE, (float) ((angle % 360) + 360) % 360, false, 0);
     }
 
     public static String formatSpeed(double speed, boolean withoutUnits) {
-        return locus.api.android.utils.UtilsFormat.formatSpeed(Preferences.FORMAT_SPEED, speed, withoutUnits);
+        return locus.api.android.utils.UtilsFormat.INSTANCE.formatSpeed(Preferences.FORMAT_SPEED, speed, withoutUnits);
     }
 
     public static String formatDistance(double dist, boolean withoutUnits) {
-        return locus.api.android.utils.UtilsFormat.formatDistance(Preferences.FORMAT_LENGTH, dist, withoutUnits);
+        return locus.api.android.utils.UtilsFormat.INSTANCE.formatDistance(Preferences.FORMAT_LENGTH, dist, withoutUnits);
     }
 
     public static String formatDouble(double value, int precision) {
-        return locus.api.android.utils.UtilsFormat.formatDouble(value, precision);
+        return locus.api.android.utils.UtilsFormat.INSTANCE.formatDouble(value, precision);
     }
 
     public static String formatDouble(double value, int precision, int minlen) {
-        return locus.api.android.utils.UtilsFormat.formatDouble(value, precision, minlen);
+        return locus.api.android.utils.UtilsFormat.INSTANCE.formatDouble(value, precision, minlen);
     }
 
     public static String addZeros(String text, int count) {


### PR DESCRIPTION
fixes  #357 

## Description
- bump Locus API library on Gradle from 0.2.7 to 0.9.45
- removed `Location` initializer with string (no longer supported)
- changed LAPI dependencies in files to newer version + required refactor of corresponding code
- changed `Location` inits with only `TAG` string resource (obsolete)
- changed `Location.Accuracy` (removed support) to horizontal accuracy
- removed dependency on locus api when loading cartridges (never fully implemented)

## Related issues
- #357 

## Additional context
- **this PR is in Do not merge / WIP state** until fully tested
- tried this fix with only one cartridge (with Locus 4 Gold @ Android 11), will do more testing of this change when outside
- more tests with other Locus versions recommended