### PR TITLE
Fix #365 - Add branch merging workflow

### DIFF
--- a/.github/workflows/branch-merge.yml
+++ b/.github/workflows/branch-merge.yml
@@ -1,0 +1,33 @@
+name: Auto-merge branches 
+
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  # It was decided to don't run the workflow automatically for now
+  #schedule:
+  #  - cron: '0 0 * * *'
+
+env:
+  REPO: https://${{secrets.ACTION_SECRET}}@github.com/cgeo/WhereYouGo.git
+  RELEASE_BRANCH: release
+  MASTER_BRANCH: master
+
+jobs:
+  # This workflow contains a single job called "merge-branches"
+  merge-branches:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone and setup the repo
+        run: |
+          git clone ${{env.REPO}} -b ${{env.MASTER_BRANCH}} tmp
+          cd tmp
+          git config --local include.path ../.gitconfig
+          git config user.name cgeo branch-merge-bot
+          git config user.email 61464155+cgeo-ci-bot@users.noreply.github.com
+      - name: Merge branches and push
+        run: | 
+          cd tmp    # path is reseted for every step, therefore we need to set it again 
+          git merge origin/${{env.RELEASE_BRANCH}} -m "merge branch '${{env.RELEASE_BRANCH}}' via workflow"
+          git push


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Adds the same workflow to automate branch merging from `release` back into `master` as we use in the cgeo repository.

The very same `ACTION_SECRET` for the user @cgeo-ci-bot was used. That should IMHO work, as this user also has a maintainer role for the WhereYouGo repository. (see: https://github.com/cgeo/cgeo/issues/11737)

## Related issues
<!-- List the related issues fixed or improved by this PR -->
#365 


## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->