### PR TITLE
Added MANAGE_EXTERNAL_STORE to manifest. This way gwc-files can be ac…

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />


### PR DESCRIPTION
Added MANAGE_EXTERNAL_STORE to manifest. This way gwc-files can be accessed when on API 30 or higher. The permission needs to be set manually on my S10 under settings. Caution: According to the Google Playstore policy that means that the app will be further evaluated by Google.
