### PR TITLE
Use NotificationCompat for API < 26 compatibility (fix #368)

### DIFF
--- a/src/main/java/menion/android/whereyougo/utils/NotificationService.java
+++ b/src/main/java/menion/android/whereyougo/utils/NotificationService.java
@@ -12,6 +12,8 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.IBinder;
 
+import androidx.core.app.NotificationCompat;
+
 public class NotificationService extends Service {
     private static final int notification_id = 10;
     private static final String NOTIFICATION_CHANNEL_ID = "menion.android.whereyougo.utils.NotificationService";
@@ -78,7 +80,7 @@ public class NotificationService extends Service {
         PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, 0);
 
 
-        Notification.Builder builder = new Notification.Builder(this, NOTIFICATION_CHANNEL_ID);
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID);
         builder.setContentTitle(contentTitel);
         builder.setSmallIcon(R.drawable.ic_title_logo_transparent);
         builder.setContentIntent(pendingIntent);


### PR DESCRIPTION
## Description
Use `NotificationCompat` instead of `Notification` to avoid crashes for notifications on API < 26