### PR TITLE
Fix longitude formatting (fix #391)

### DIFF
--- a/src/main/java/menion/android/whereyougo/gui/activity/CartridgeDetailsActivity.java
+++ b/src/main/java/menion/android/whereyougo/gui/activity/CartridgeDetailsActivity.java
@@ -83,7 +83,7 @@ public class CartridgeDetailsActivity extends CustomActivity {
                 "</b>" + "<br />" + getString(R.string.latitude) + ": " +
                 UtilsFormat.formatLatitude(MainActivity.cartridgeFile.latitude) + "<br />" +
                 getString(R.string.longitude) + ": " +
-                UtilsFormat.formatLatitude(MainActivity.cartridgeFile.longitude);
+                UtilsFormat.formatLongitude(MainActivity.cartridgeFile.longitude);
 
         tvDistance.setText(Html.fromHtml(buff));
 


### PR DESCRIPTION
## Description
Fix longitude formatting on opening screen by using `formatLongitude()` instead of `formatLatitude()`
