### PR TITLE
Update targetSDK to 31 (fix #416)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,9 @@ android {
 
     defaultConfig {
         applicationId "menion.android.whereyougo"
-        minSdkVersion 21
+        minSdk 21
         //noinspection OldTargetApi
-        targetSdkVersion 30
+        targetSdk 31
 
         versionName versionNameFromDate()
         versionCode versionCodeFromDate(0)

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -36,7 +36,8 @@
         android:preserveLegacyExternalStorage="true">
         <activity
             android:name="menion.android.whereyougo.gui.activity.MainActivity"
-            android:label="WhereYouGo">
+            android:label="WhereYouGo"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/src/main/java/menion/android/whereyougo/utils/NotificationService.java
+++ b/src/main/java/menion/android/whereyougo/utils/NotificationService.java
@@ -75,8 +75,7 @@ public class NotificationService extends Service {
         Intent intent = new Intent(context, menion.android.whereyougo.gui.activity.MainActivity.class);
         intent.addCategory(Intent.CATEGORY_LAUNCHER);
         intent.setAction(Intent.ACTION_MAIN);
-        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, 0);
-
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_IMMUTABLE : 0);
 
         Notification.Builder builder = new Notification.Builder(this, NOTIFICATION_CHANNEL_ID);
         builder.setContentTitle(contentTitel);


### PR DESCRIPTION
## Description
To be able to upload new versions of WhereYouGo to Play Store we must raise targetSDK to at least 31, which this PR does, including the most prominent adaptions required for it.
