### PR TITLE
Map picker workaround for private folder

### DIFF
--- a/src/main/java/menion/android/whereyougo/maps/mapsforge/filepicker/FilePicker.java
+++ b/src/main/java/menion/android/whereyougo/maps/mapsforge/filepicker/FilePicker.java
@@ -55,11 +55,11 @@ public class FilePicker extends Activity implements AdapterView.OnItemClickListe
      */
     public static final String SELECTED_FILE = "selectedFile";
 
-    private static final String CURRENT_DIRECTORY = "currentDirectory";
+    public static final String CURRENT_DIRECTORY = "currentDirectory";
     private static final String DEFAULT_DIRECTORY = "/";
     private static final int DIALOG_FILE_INVALID = 0;
     private static final int DIALOG_FILE_SELECT = 1;
-    private static final String PREFERENCES_FILE = "FilePicker";
+    public static final String PREFERENCES_FILE = "FilePicker";
     private static Comparator<File> fileComparator = getDefaultFileComparator();
     private static FileFilter fileDisplayFilter;
     private static ValidFileFilter fileSelectFilter;

--- a/src/main/java/menion/android/whereyougo/maps/mapsforge/preferences/EditPreferences.java
+++ b/src/main/java/menion/android/whereyougo/maps/mapsforge/preferences/EditPreferences.java
@@ -15,11 +15,16 @@
 package menion.android.whereyougo.maps.mapsforge.preferences;
 
 import menion.android.whereyougo.R;
+import menion.android.whereyougo.maps.mapsforge.filepicker.FilePicker;
 
+import android.app.AlertDialog;
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceManager;
 import android.view.WindowManager;
+import android.widget.Toast;
 
 /**
  * Activity to edit the application preferences.
@@ -29,6 +34,37 @@ public class EditPreferences extends PreferenceActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         addPreferencesFromResource(R.xml.mapsforge_preferences);
+
+        Preference resetCurrentDirectoryPrivate = findPreference("resetCurrentDirectoryPrivate");
+        if (resetCurrentDirectoryPrivate != null) {
+            resetCurrentDirectoryPrivate.setOnPreferenceClickListener(preference -> resetCurrentDirectory(true));
+        }
+
+        Preference resetCurrentDirectoryRoot = findPreference("resetCurrentDirectoryRoot");
+        if (resetCurrentDirectoryRoot != null) {
+            resetCurrentDirectoryRoot.setOnPreferenceClickListener(preference -> resetCurrentDirectory(false));
+        }
+
+    }
+
+    private boolean resetCurrentDirectory(final boolean toPrivateFolder) {
+        new AlertDialog.Builder(this)
+            .setTitle(R.string.reset_map_settings_confirmation_title)
+            .setMessage(R.string.reset_map_settings_confirmation_message)
+            .setPositiveButton(android.R.string.ok, ((dialogInterface, i) -> {
+                SharedPreferences.Editor editor = getSharedPreferences(FilePicker.PREFERENCES_FILE, MODE_PRIVATE).edit();
+                editor.putString(FilePicker.CURRENT_DIRECTORY, toPrivateFolder ? getExternalFilesDir(null).getAbsolutePath() : "/");
+                editor.commit();
+
+                SharedPreferences.Editor editor2 = getSharedPreferences("MapActivity", MODE_PRIVATE).edit();
+                editor2.remove("mapFile");
+                editor2.commit();
+
+                Toast.makeText(this, R.string.reset_current_directory_info, Toast.LENGTH_SHORT).show();
+            }))
+            .setNegativeButton(android.R.string.cancel, (dialogInterface, i) -> {})
+            .show();
+        return true;
     }
 
     @Override

--- a/src/main/res/values/strings_mapsforge.xml
+++ b/src/main/res/values/strings_mapsforge.xml
@@ -113,4 +113,14 @@
     <string name="receivemapfile_success">Mapfile set</string>
     <string name="receivemapfile_error">Error setting mapfile</string>
     <string name="receivemapfile_notset">No mapfile set in c:geo</string>
+
+    <!-- Reset map source (and default folder) settings -->
+    <string name="reset_current_directory_private_title">Reset to private</string>
+    <string name="reset_current_directory_private_summary">Reset current directory to private directory (use this on Android 11 or newer)</string>
+    <string name="reset_current_directory_root_title">Reset to root</string>
+    <string name="reset_current_directory_root_summary">Reset current directory to root directory (use this on Android 10 or older</string>
+    <string name="reset_current_directory_info">Current directory reset</string>
+
+    <string name="reset_map_settings_confirmation_title">Reset map source settings</string>
+    <string name="reset_map_settings_confirmation_message">This will reset your map source setting and your current map base folder.\n\nYou will need to restart WhereYouGo and select a new map source.</string>
 </resources>

--- a/src/main/res/xml/mapsforge_preferences.xml
+++ b/src/main/res/xml/mapsforge_preferences.xml
@@ -67,5 +67,14 @@
             android:key="highlightWaterTiles"
             android:summary="@string/preferences_show_water_tiles_desc"
             android:title="@string/preferences_show_water_tiles" />
+        <Preference
+            android:key="resetCurrentDirectoryPrivate"
+            android:summary="@string/reset_current_directory_private_summary"
+            android:title="@string/reset_current_directory_private_title" />
+        <Preference
+            android:key="resetCurrentDirectoryRoot"
+            android:summary="@string/reset_current_directory_root_summary"
+            android:title="@string/reset_current_directory_root_title" />
+
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
## Description
Since more recent versions of Android WhereYouGo can no longer access public folders to load Mapsforge map files.
WhereYouGo can still read its private folder in `Android/data/menion.whereyougo.com/files`, but the internal file picker cannot reach that folder.

This PR allows resetting the starting point for the internal file picker to either "root" (as it is currently) or "private" folder. It also resets the internally stored last map file name, so that WhereYouGo resorts to the (reset) default folder, effectively allowing the user to select map files stored in WhereYouGo private folder.

Users are able to put map files into that private folder by connecting their mobile to a PC and transferring the map file from there to the mentioned private folder.

## Additional context

|new preferences|confirmation|select map from private folder|
|---|---|---|
|![image](https://github.com/cgeo/WhereYouGo/assets/3754370/a3fac92f-39e3-44e4-89b5-291a7513dd42)|![image](https://github.com/cgeo/WhereYouGo/assets/3754370/c5e06d69-acab-4590-b467-ecba6a63ac84)|![image](https://github.com/cgeo/WhereYouGo/assets/3754370/52d246bc-6c89-463d-a07e-3442f4e0f2a0)|

